### PR TITLE
Fix(conf): remove typo for hibernate configuration

### DIFF
--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -4,7 +4,7 @@ spring:
 
   jpa:
     properties:
-      hibernates:
+      hibernate:
         order_inserts: true
         order_updates: true
         jdbc:


### PR DESCRIPTION
it's hibernate not hibernate~~s~~
broken when moving conf around in [2f427c3](https://github.com/gridsuite/report-server/commit/2f427c3842488b) in nov 24 2021