### PR TITLE
Fix Liquibase `diff` when JPA entities not modified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 /target/
 /.idea/
 /*.iml
+
+# https://github.com/liquibase/liquibase/issues/2196
+/derby.log

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent-ws</artifactId>
-        <version>17</version>
+        <version>18</version>
         <relativePath/>
     </parent>
 

--- a/src/main/resources/db/changelog/changesets/changelog_20230811T114900Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20230811T114900Z.xml
@@ -3,10 +3,10 @@
     <changeSet author="hedhiliabd" id="1689623201842-1">
         <validCheckSum>8:016d50ff3c894c57034f65489fcd2818</validCheckSum>
         <modifyDataType columnName="value_type"
-                        newDataType="tinyint"
+                        newDataType="smallint"
                         tableName="report_element_entity_values"/>
         <modifyDataType columnName="value_type"
-                        newDataType="tinyint"
+                        newDataType="smallint"
                         tableName="tree_report_entity_values"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changesets/changelog_20231017T142951Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20231017T142951Z.xml
@@ -1,0 +1,33 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="chuinetri (base generated)" id="1697553004217-1">
+        <!-- there is an index on the column because of a foreign key, so to be able to drop the PK (and delete the associated index), we need to firstly drop the forign key-->
+        <dropForeignKeyConstraint baseTableName="report_element_entity_values" constraintName="treeReportEmbeddable_subReports_fk"/>
+        <dropPrimaryKey tableName="report_element" dropIndex="true"/>
+
+        <dropForeignKeyConstraint baseTableName="tree_report_entity_dictionary" constraintName="treeReportEntity_dictionary_fk"/>
+        <dropForeignKeyConstraint baseTableName="tree_report_entity_values" constraintName="treeReportEmbeddable_name_fk"/>
+        <dropForeignKeyConstraint baseTableName="report_element" constraintName="treeReportElement_id_fk_constraint"/>
+        <dropForeignKeyConstraint baseTableName="tree_report" constraintName="treeReport_id_fk_constraint"/>
+        <dropPrimaryKey tableName="tree_report" dropIndex="true"/>
+
+        <dropForeignKeyConstraint baseTableName="tree_report" constraintName="report_id_fk_constraint"/>
+        <dropPrimaryKey tableName="report" dropIndex="true"/>
+    </changeSet>
+    <changeSet author="chuinetri (base generated)" id="1697553004217-2">
+        <addPrimaryKey columnNames="id" constraintName="reportPK" tableName="report"/>
+        <addPrimaryKey columnNames="id_report" constraintName="report_elementPK" tableName="report_element"/>
+        <addPrimaryKey columnNames="id_node" constraintName="tree_reportPK" tableName="tree_report"/>
+
+        <addForeignKeyConstraint baseColumnNames="report" baseTableName="tree_report" constraintName="report_id_fk_constraint" deferrable="false" initiallyDeferred="false" referencedColumnNames="id" referencedTableName="report" validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="parent_report" baseTableName="report_element" constraintName="treeReportElement_id_fk_constraint" deferrable="false" initiallyDeferred="false" referencedColumnNames="id_node" referencedTableName="tree_report" validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="tree_report_entity_id_node" baseTableName="tree_report_entity_values" constraintName="treeReportEmbeddable_name_fk" deferrable="false" initiallyDeferred="false" referencedColumnNames="id_node" referencedTableName="tree_report" validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="report_element_entity_id_report" baseTableName="report_element_entity_values" constraintName="treeReportEmbeddable_subReports_fk" deferrable="false" initiallyDeferred="false" referencedColumnNames="id_report" referencedTableName="report_element" validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="tree_report_entity_id_node" baseTableName="tree_report_entity_dictionary" constraintName="treeReportEntity_dictionary_fk" deferrable="false" initiallyDeferred="false" referencedColumnNames="id_node" referencedTableName="tree_report" validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="parent_report" baseTableName="tree_report" constraintName="treeReport_id_fk_constraint" deferrable="false" initiallyDeferred="false" referencedColumnNames="id_node" referencedTableName="tree_report" validate="true"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,29 +1,25 @@
 databaseChangeLog:
-
   - include:
       file: changesets/changelog_20211019T140751Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220330T140829Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220617T153215Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220627T090000Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20220906T090000Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20221012T095413Z.xml
       relativeToChangelogFile: true
-
   - include:
       file: changesets/changelog_20230811T114900Z.xml
+      relativeToChangelogFile: true
+  - include:
+      file: changesets/changelog_20231017T142951Z.xml
       relativeToChangelogFile: true

--- a/src/test/resources/application-default.yaml
+++ b/src/test/resources/application-default.yaml
@@ -15,5 +15,5 @@ logging:
 powsybl-ws:
   database:
     vendor: h2:mem
-    query: ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    query: ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL;DEFAULT_NULL_ORDERING=HIGH
     hostPort: ":"


### PR DESCRIPTION
Liquibase `diff` generate changes when using `main` branch without modifying JPA entities.  
* The diff come from recent migrations updating some rules in Liquibase.
* Also add missing compatibility mode in H2 configuration
* ⚠️ need release v18 of powsybl/powsybl-parent/pull/54