### PR TITLE
partition the report deletion requests

### DIFF
--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -42,7 +42,9 @@ public class ReportService {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReportService.class);
 
     private static final long NANOS_FROM_EPOCH_TO_START;
-    private static final int REQUEST_MAX_PARAM_NUMBER = 10000; // the maximum number of parameters allowed in an In request
+
+    // the maximum number of parameters allowed in an In query. Prevents the number of parameters to reach the maximum allowed (65,535)
+    private static final int SQL_QUERY_MAX_PARAM_NUMBER = 10000;
 
     /**
      * @see TypedValue
@@ -238,10 +240,10 @@ public class ReportService {
      */
     private void deleteRoot(UUID rootTreeReportId) {
         List<UUID> treeReportIds = treeReportRepository.getSubReportsNodes(rootTreeReportId).stream().map(UUID::fromString).toList();
-        List<UUID> reportIds = reportElementRepository.findIdReportByParentReportIdNodeIn(treeReportIds)
+        List<UUID> reportElementIds = reportElementRepository.findIdReportByParentReportIdNodeIn(treeReportIds)
             .stream().map(ReportElementEntity.ProjectionIdReport::getIdReport).toList();
 
-        Lists.partition(reportIds, REQUEST_MAX_PARAM_NUMBER) // prevents the number of in request parameters to reach the maximum allowed (65,535)
+        Lists.partition(reportElementIds, SQL_QUERY_MAX_PARAM_NUMBER)
                 .forEach(reportElementRepository::deleteAllByIdReportIn);
 
         treeReportRepository.deleteAllByIdNodeIn(treeReportIds);


### PR DESCRIPTION
The request deleting the reports from the database crashes when the reports to be deleted are more than 65535.

This PR partition this request into several smaller requests in order to limit the maximum size to 10000.

I set the limitation to 10000 quite arbitrarly. I didn't get any performance difference when decreasing or increasing it (as long as it remains under 65535 obviously).

I didn't use .parallelStream() on the partitioned streams because it causes the following error : 

```
java.lang.reflect.InvocationTargetException
org.springframework.dao.InvalidDataAccessApiUsageException: No EntityManager with actual transaction available for current thread - cannot reliably process 'remove' call
```