### PR TITLE
Fix hibernate insert ordering misfunction for report-server entities

### DIFF
--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -206,11 +206,11 @@ public class ReportService {
         List<ReportElementEntity> reportElementEntities = new ArrayList<>();
 
         List<ReporterModel> subReporters = reporterModel.getSubReporters();
-        IntStream.range(0, subReporters.size()).forEach(idx -> reportElementEntities.addAll(traverseReportModel(null, subReporters.get(idx), treeReportEntity)));
+        reportElementEntities.addAll(IntStream.range(0, subReporters.size()).mapToObj(idx -> traverseReportModel(null, subReporters.get(idx), treeReportEntity)).flatMap(List::stream).collect(Collectors.toList()));
 
         Collection<Report> reports = reporterModel.getReports();
         List<Report> reportsAsList = new ArrayList<>(reports);
-        IntStream.range(0, reportsAsList.size()).forEach(idx -> reportElementEntities.add(toReportElementEntity(treeReportEntity, reportsAsList.get(idx), dict)));
+        reportElementEntities.addAll(IntStream.range(0, reportsAsList.size()).mapToObj(idx -> toReportElementEntity(treeReportEntity, reportsAsList.get(idx), dict)).collect(Collectors.toList()));
 
         return reportElementEntities;
     }

--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -190,29 +190,37 @@ public class ReportService {
         return persistedReport;
     }
 
-    private TreeReportEntity toEntity(ReportEntity persistedReport, ReporterModel reporterModel, TreeReportEntity parentNode) {
+    private void toEntity(ReportEntity persistedReport, ReporterModel reporterModel, TreeReportEntity parentNode) {
+        // This return a list of ReportElementEntity to be saved at the end, otherwise
+        // hibernate.order_insert don't work properly since https://hibernate.atlassian.net/browse/HHH-16485 hibernate 6.2.2
+        List<ReportElementEntity> reportElements = browseReportModeltoEntity(persistedReport, reporterModel, parentNode);
+        reportElementRepository.saveAll(reportElements);
+    }
+
+    private List<ReportElementEntity> browseReportModeltoEntity(ReportEntity persistedReport, ReporterModel reporterModel, TreeReportEntity parentNode) {
         Map<String, String> dict = new HashMap<>();
         dict.put(reporterModel.getTaskKey(), reporterModel.getDefaultName());
-        var newTreeReportEntity = new TreeReportEntity(null, reporterModel.getTaskKey(), persistedReport,
+        TreeReportEntity treeReportEntity = treeReportRepository.save(new TreeReportEntity(null, reporterModel.getTaskKey(), persistedReport,
                 toValueEntityList(reporterModel.getTaskValues()), parentNode, dict,
-                System.nanoTime() - NANOS_FROM_EPOCH_TO_START);
-        var treeReportEntity = treeReportRepository.save(newTreeReportEntity);
+                System.nanoTime() - NANOS_FROM_EPOCH_TO_START));
+
+        List<ReportElementEntity> reportElementEntities = new ArrayList<>();
 
         List<ReporterModel> subReporters = reporterModel.getSubReporters();
-        IntStream.range(0, subReporters.size()).forEach(idx -> toEntity(null, subReporters.get(idx), treeReportEntity));
+        IntStream.range(0, subReporters.size()).forEach(idx -> reportElementEntities.addAll(browseReportModeltoEntity(null, subReporters.get(idx), treeReportEntity)));
 
         Collection<Report> reports = reporterModel.getReports();
         List<Report> reportsAsList = new ArrayList<>(reports);
-        IntStream.range(0, reportsAsList.size()).forEach(idx -> toEntity(treeReportEntity, reportsAsList.get(idx), dict));
+        IntStream.range(0, reportsAsList.size()).forEach(idx -> reportElementEntities.add(toReportElementEntity(treeReportEntity, reportsAsList.get(idx), dict)));
 
-        return treeReportEntity;
+        return reportElementEntities;
     }
 
-    private ReportElementEntity toEntity(TreeReportEntity parentReport, Report report, Map<String, String> dict) {
+    private ReportElementEntity toReportElementEntity(TreeReportEntity parentReport, Report report, Map<String, String> dict) {
         dict.put(report.getReportKey(), report.getDefaultMessage());
-        return reportElementRepository.save(new ReportElementEntity(null, parentReport,
+        return new ReportElementEntity(null, parentReport,
             System.nanoTime() - NANOS_FROM_EPOCH_TO_START,
-            report.getReportKey(), toValueEntityList(report.getValues())));
+            report.getReportKey(), toValueEntityList(report.getValues()));
     }
 
     private List<ReportValueEmbeddable> toValueEntityList(Map<String, TypedValue> values) {

--- a/src/test/java/org/gridsuite/report/server/ReportControllerTest.java
+++ b/src/test/java/org/gridsuite/report/server/ReportControllerTest.java
@@ -156,6 +156,8 @@ public class ReportControllerTest {
         String testReport1 = toString(REPORT_ONE);
         insertReport(REPORT_UUID, testReport1);
 
+        assertRequestsCount(2, 2, 0, 0);
+        //12 insert for now
         SQLStatementCountValidator.reset();
 
         mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID))
@@ -270,6 +272,10 @@ public class ReportControllerTest {
     public void testDeleteSubreports() throws Exception {
         String testReportLoadflow = toString(REPORT_LOADFLOW);
         insertReport(REPORT_UUID, testReportLoadflow);
+        
+        // Expect 4 batched inserts only and no updates
+        assertRequestsCount(2, 4, 0, 0);
+
         Map<UUID, String> reportsKeys = new HashMap<>();
         reportsKeys.put(UUID.fromString(REPORT_UUID), "LoadFlow");
 

--- a/src/test/java/org/gridsuite/report/server/ReportControllerTest.java
+++ b/src/test/java/org/gridsuite/report/server/ReportControllerTest.java
@@ -156,8 +156,8 @@ public class ReportControllerTest {
         String testReport1 = toString(REPORT_ONE);
         insertReport(REPORT_UUID, testReport1);
 
-        assertRequestsCount(2, 2, 0, 0);
-        //12 insert for now
+        // expect 6 batched inserts of different tables and no updates
+        assertRequestsCount(2, 6, 0, 0);
         SQLStatementCountValidator.reset();
 
         mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID))

--- a/src/test/java/org/gridsuite/report/server/ReportControllerTest.java
+++ b/src/test/java/org/gridsuite/report/server/ReportControllerTest.java
@@ -272,7 +272,7 @@ public class ReportControllerTest {
     public void testDeleteSubreports() throws Exception {
         String testReportLoadflow = toString(REPORT_LOADFLOW);
         insertReport(REPORT_UUID, testReportLoadflow);
-        
+
         // Expect 4 batched inserts only and no updates
         assertRequestsCount(2, 4, 0, 0);
 


### PR DESCRIPTION
Workaround : save ReportElementEntities after the ReportModel tree traversal which save TreeReportEntities first to avoid insert ordering misfunction and restore batch inserts.

Add an assert to test this case to avoid future regression

this order insertion misfunction was introduce by : https://hibernate.atlassian.net/browse/HHH-16485 hibernate 6.2.2
see https://hibernate.atlassian.net/browse/HHH-17529