### PR TITLE
feat(api): remove withElements option in reports endpoint

### DIFF
--- a/src/main/java/org/gridsuite/report/server/ReportController.java
+++ b/src/main/java/org/gridsuite/report/server/ReportController.java
@@ -42,13 +42,12 @@ public class ReportController {
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The elements of the report, reporters and subreporters"),
         @ApiResponse(responseCode = "404", description = "The report does not exists")})
     public ResponseEntity<List<ReportNode>> getReport(@PathVariable("id") UUID id,
-                                                         @Parameter(description = "Fetch the report's elements") @RequestParam(name = "withElements", required = false, defaultValue = "false") boolean withElements,
-                                                         @Parameter(description = "Filter on a the report name. If provided, will only return elements matching this given name.") @RequestParam(name = "reportNameFilter", required = false, defaultValue = "") String reportNameFilter,
-                                                         @Parameter(description = "Kind of matching filter to apply to the report name.") @RequestParam(name = "reportNameMatchingType", required = false) ReportService.ReportNameMatchingType reportNameMatchingType,
-                                                         @Parameter(description = "Filter on severity levels. Will only return elements with those severities.") @RequestParam(name = "severityLevels", required = false) Set<String> severityLevels,
-                                                         @Parameter(description = "Empty report with default name") @RequestParam(name = "defaultName", required = false, defaultValue = "defaultName") String defaultName) {
+                                                      @Parameter(description = "Filter on a the report name. If provided, will only return elements matching this given name.") @RequestParam(name = "reportNameFilter", required = false, defaultValue = "") String reportNameFilter,
+                                                      @Parameter(description = "Kind of matching filter to apply to the report name.") @RequestParam(name = "reportNameMatchingType", required = false) ReportService.ReportNameMatchingType reportNameMatchingType,
+                                                      @Parameter(description = "Filter on severity levels. Will only return elements with those severities.") @RequestParam(name = "severityLevels", required = false) Set<String> severityLevels,
+                                                      @Parameter(description = "Empty report with default name") @RequestParam(name = "defaultName", required = false, defaultValue = "defaultName") String defaultName) {
         try {
-            List<ReportNode> subReporters = service.getReport(id, withElements, withElements ? severityLevels : null, reportNameFilter, reportNameMatchingType).getChildren();
+            List<ReportNode> subReporters = service.getReport(id, severityLevels, reportNameFilter, reportNameMatchingType).getChildren();
             return subReporters.isEmpty() ?
                 ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(service.getEmptyReport(id, defaultName).getChildren()) :
                 ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(subReporters);

--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -92,7 +92,7 @@ public class ReportService {
     }
 
     @Transactional(readOnly = true)
-    public ReportNode getReport(UUID reportId, boolean withElements, Set<String> severityLevels, String reportNameFilter, ReportNameMatchingType reportNameMatchingType) {
+    public ReportNode getReport(UUID reportId, @Nullable Set<String> severityLevels, String reportNameFilter, @Nullable ReportNameMatchingType reportNameMatchingType) {
         Objects.requireNonNull(reportId);
         ReportEntity reportEntity = reportRepository.findById(reportId).orElseThrow(EntityNotFoundException::new);
 
@@ -107,7 +107,7 @@ public class ReportService {
                         || reportNameMatchingType == ReportNameMatchingType.EXACT_MATCHING && tre.getName().equals(reportNameFilter)
                         || reportNameMatchingType == ReportNameMatchingType.ENDS_WITH && tre.getName().endsWith(reportNameFilter)).toList();
 
-        treeReportEntities.forEach(treeReportEntity -> addSubReportNode(rootReportNode, treeReportEntity, withElements, severityLevels));
+        treeReportEntities.forEach(treeReportEntity -> addSubReportNode(rootReportNode, treeReportEntity, severityLevels));
 
         return rootReportNode;
     }
@@ -121,33 +121,29 @@ public class ReportService {
                 .withMessageTemplate(treeReportEntity.getIdNode().toString(), treeReportEntity.getIdNode().toString())
                 .build();
 
-        addSubReportNode(report, treeReportEntity, true, severityLevels);
+        addSubReportNode(report, treeReportEntity, severityLevels);
 
         return report;
     }
 
-    private ReportNode addSubReportNode(ReportNode rootReportNdoe, TreeReportEntity subTreeReport, boolean withElements, Set<String> severityLevels) {
+    private void addSubReportNode(ReportNode rootReportNdoe, TreeReportEntity subTreeReport, @Nullable Set<String> severityLevels) {
         // Let's find all the treeReportEntities ids that inherit from the parent treeReportEntity
         final List<UUID> treeReportEntitiesIds = treeReportRepository.findAllTreeReportIdsRecursivelyByParentTreeReport(subTreeReport.getIdNode())
                 .stream()
                 .map(UUID::fromString)
                 .toList();
 
-        List<ReportElementEntity> allReportElements = null;
-        if (withElements) {
-            // Let's find all the reportElements that are linked to the found treeReports
-            allReportElements = reportElementRepository.findAllByParentReportIdNodeInOrderByNanos(treeReportEntitiesIds)
-                    .stream()
-                    .filter(reportElementEntity -> reportElementEntity.hasSeverity(severityLevels) || reportElementEntity.getValues().isEmpty()) // reportElementEntity.getValues().isEmpty() is a hack to get the empty subreports
-                    .toList();
-        }
+        // Let's find all the reportElements that are linked to the found treeReports
+        List<ReportElementEntity> allReportElements = reportElementRepository.findAllByParentReportIdNodeInOrderByNanos(treeReportEntitiesIds)
+            .stream()
+            .filter(reportElementEntity -> reportElementEntity.hasSeverity(severityLevels) || reportElementEntity.getValues().isEmpty()) // reportElementEntity.getValues().isEmpty() is a hack to get the empty subreports
+            .toList();
 
         // We need to get the entities to have access to the dictionaries
         List<TreeReportEntity> treeReportEntities = treeReportRepository.findAllByIdNodeInOrderByNanos(treeReportEntitiesIds);
 
         // Now we can rebuild the tree
         addSubReportNode(rootReportNdoe, subTreeReport, treeReportEntities, allReportElements);
-        return rootReportNdoe;
     }
 
     private void addSubReportNode(final ReportNode rootReportNode, final TreeReportEntity rootTreeReportEntity, final List<TreeReportEntity> allTreeReports,

--- a/src/main/java/org/gridsuite/report/server/entities/ReportElementEntity.java
+++ b/src/main/java/org/gridsuite/report/server/entities/ReportElementEntity.java
@@ -16,6 +16,7 @@ import org.gridsuite.report.server.ReportService;
 import org.gridsuite.report.server.entities.ReportValueEmbeddable.ValueType;
 import org.springframework.util.CollectionUtils;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -57,7 +58,7 @@ public class ReportElementEntity {
         indexes = @Index(name = "reportElementValues_index", columnList = "report_element_entity_id_report"))
     List<ReportValueEmbeddable> values;
 
-    public boolean hasSeverity(Set<String> severityLevels) {
+    public boolean hasSeverity(@Nullable Set<String> severityLevels) {
         if (CollectionUtils.isEmpty(severityLevels)) {
             return false;
         } else {

--- a/src/test/java/org/gridsuite/report/server/ReportControllerTest.java
+++ b/src/test/java/org/gridsuite/report/server/ReportControllerTest.java
@@ -131,7 +131,7 @@ public class ReportControllerTest {
         String testReport1 = toString(REPORT_ONE);
         insertReport(REPORT_UUID, testReport1);
 
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR"))
+        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR"))
             .andExpect(status().isOk())
             .andExpect(content().json(toString(EXPECTED_SINGLE_REPORT)));
 
@@ -146,13 +146,13 @@ public class ReportControllerTest {
 
         mvc.perform(delete(URL_TEMPLATE + "/reports/" + REPORT_UUID)).andExpect(status().isNotFound());
 
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true"))
+        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID))
                 .andExpect(content().json(toString(DEFAULT_EMPTY_REPORT1)))
                 .andExpect(status().isOk());
     }
 
     @Test
-    public void testGetReportNoElements() throws Exception {
+    public void testGetReport() throws Exception {
         String testReport1 = toString(REPORT_ONE);
         insertReport(REPORT_UUID, testReport1);
 
@@ -164,17 +164,17 @@ public class ReportControllerTest {
             .andExpect(status().isOk())
             .andExpect(content().json(toString(EXPECTED_STRUCTURE_ONLY_REPORT1)));
 
-        assertRequestsCount(3, 0, 0, 0);
+        assertRequestsCount(4, 0, 0, 0);
     }
 
     @Test
-    public void testGetReportWithElements() throws Exception {
+    public void testGetReportWithSeverityFilters() throws Exception {
         String testReport1 = toString(REPORT_ONE);
         insertReport(REPORT_UUID, testReport1);
 
         SQLStatementCountValidator.reset();
 
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR"))
+        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR"))
             .andExpect(status().isOk())
             .andExpect(content().json(toString(EXPECTED_STRUCTURE_AND_ELEMENTS_REPORT1)))
             .andReturn();
@@ -189,7 +189,7 @@ public class ReportControllerTest {
 
         SQLStatementCountValidator.reset();
         final String filterValue = "roundTripReporterJsonTest";
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR&reportNameFilter=" + filterValue + "&reportNameMatchingType=EXACT_MATCHING"))
+        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR&reportNameFilter=" + filterValue + "&reportNameMatchingType=EXACT_MATCHING"))
                 .andExpect(status().isOk())
                 .andExpect(content().json(toString(EXPECTED_STRUCTURE_AND_ELEMENTS_REPORT1)));
 
@@ -203,7 +203,7 @@ public class ReportControllerTest {
 
         SQLStatementCountValidator.reset();
         final String filterValue = "__noMatchingValue__";
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&reportNameFilter=" + filterValue + "&reportNameMatchingType=EXACT_MATCHING"))
+        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?reportNameFilter=" + filterValue + "&reportNameMatchingType=EXACT_MATCHING"))
                 .andExpect(status().isOk())
                 .andExpect(content().json(toString(DEFAULT_EMPTY_REPORT1)));
 
@@ -217,7 +217,7 @@ public class ReportControllerTest {
 
         SQLStatementCountValidator.reset();
         final String filterEndsWithValue = "ReporterJsonTest";
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR&reportNameFilter=" + filterEndsWithValue + "&reportNameMatchingType=ENDS_WITH"))
+        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR&reportNameFilter=" + filterEndsWithValue + "&reportNameMatchingType=ENDS_WITH"))
                 .andExpect(status().isOk())
                 .andExpect(content().json(toString(EXPECTED_STRUCTURE_AND_ELEMENTS_REPORT1)));
 
@@ -232,7 +232,7 @@ public class ReportControllerTest {
         SQLStatementCountValidator.reset();
         final String filterEndsWithValue = "__noMatchingValue__";
 
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&reportNameFilter=" + filterEndsWithValue + "&reportNameMatchingType=ENDS_WITH"))
+        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?reportNameFilter=" + filterEndsWithValue + "&reportNameMatchingType=ENDS_WITH"))
                 .andExpect(status().isOk())
                 .andExpect(content().json(toString(DEFAULT_EMPTY_REPORT1)));
 
@@ -245,7 +245,7 @@ public class ReportControllerTest {
         insertReport(REPORT_UUID, testReport1);
 
         SQLStatementCountValidator.reset();
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true"))
+        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID))
                 .andExpect(status().isOk())
                 .andExpect(content().json(toString(EXPECTED_STRUCTURE_AND_NO_REPORT_ELEMENT)))
                 .andReturn();
@@ -318,7 +318,7 @@ public class ReportControllerTest {
             .andExpect(status().isOk())
             .andReturn();
 
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true"))
+        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID))
             .andExpect(status().isOk())
             .andExpect(content().json(toString(DEFAULT_EMPTY_REPORT1)));
     }
@@ -341,7 +341,7 @@ public class ReportControllerTest {
 
         assertRequestsCount(3, 0, 0, 8);
 
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true"))
+        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID))
                 .andExpect(status().isOk())
                 .andExpect(content().json(toString(DEFAULT_EMPTY_REPORT1)));
     }
@@ -365,12 +365,12 @@ public class ReportControllerTest {
         // no deletion here
         assertRequestsCount(1, 0, 0, 0);
 
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true"))
+        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID))
                 .andExpect(status().isOk());
     }
 
     private void testImported(String report1Id, String reportConcat2) throws Exception {
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + report1Id + "?withElements=true&severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR"))
+        mvc.perform(get(URL_TEMPLATE + "/reports/" + report1Id + "?severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR"))
             .andExpect(status().isOk())
             .andExpect(content().json(toString(reportConcat2)));
     }

--- a/src/test/java/org/gridsuite/report/server/TreeReportTest.java
+++ b/src/test/java/org/gridsuite/report/server/TreeReportTest.java
@@ -73,7 +73,7 @@ class TreeReportTest {
         TreeReportEntity treeReportEntity3 = createTreeReport("log3", reportEntity, null, 1000);
         treeReportRepository.saveAll(List.of(treeReportEntity1, treeReportEntity2, treeReportEntity3));
 
-        ReportNode report = reportService.getReport(idReport, false, null, "", ReportService.ReportNameMatchingType.EXACT_MATCHING);
+        ReportNode report = reportService.getReport(idReport, null, "", ReportService.ReportNameMatchingType.EXACT_MATCHING);
         assertEquals(List.of("log3", "log1", "log2"), report.getChildren().stream().map(ReportNode::getMessageKey).toList());
     }
 
@@ -89,7 +89,7 @@ class TreeReportTest {
         TreeReportEntity treeReportEntity3 = createTreeReport("log3", null, treeReportEntity, 1000);
         treeReportRepository.saveAll(List.of(treeReportEntity1, treeReportEntity2, treeReportEntity3));
 
-        ReportNode report = reportService.getReport(idReport, false, null, "", ReportService.ReportNameMatchingType.EXACT_MATCHING);
+        ReportNode report = reportService.getReport(idReport, null, "", ReportService.ReportNameMatchingType.EXACT_MATCHING);
         ReportNode reporter = report.getChildren().get(0);
         assertEquals(List.of("log3", "log1", "log2"), reporter.getChildren().stream().map(ReportNode::getMessageKey).toList());
     }
@@ -106,7 +106,7 @@ class TreeReportTest {
         ReportElementEntity reportElement3 = createReportElement("log3", treeReportEntity, 1000, "TRACE");
         reportElementRepository.saveAll(List.of(reportElement1, reportElement2, reportElement3));
 
-        ReportNode report = reportService.getReport(idReport, true, Set.of("INFO", "TRACE", "ERROR"), "", ReportService.ReportNameMatchingType.EXACT_MATCHING);
+        ReportNode report = reportService.getReport(idReport, Set.of("INFO", "TRACE", "ERROR"), "", ReportService.ReportNameMatchingType.EXACT_MATCHING);
         ReportNode reporter = report.getChildren().get(0);
 
         assertEquals(List.of("log3", "log1", "log2"), reporter.getChildren().stream().map(ReportNode::getMessageKey).toList());


### PR DESCRIPTION
This parameter is not used anymore (always set to true in client calls) and it does not make sense anymore with the new ReportNode model so we remove it to make internal report-server DB migration easier.