### PR TITLE
fix: controller tests files

### DIFF
--- a/src/test/java/org/gridsuite/report/server/ReportControllerTest.java
+++ b/src/test/java/org/gridsuite/report/server/ReportControllerTest.java
@@ -69,30 +69,6 @@ public class ReportControllerTest {
     public void setUp() {
         Configuration.defaultConfiguration();
         MockitoAnnotations.openMocks(this);
-        objectMapper.enable(DeserializationFeature.USE_LONG_FOR_INTS);
-        objectMapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
-        objectMapper.disable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE);
-
-        Configuration.setDefaults(new Configuration.Defaults() {
-
-            private final JsonProvider jsonProvider = new JacksonJsonProvider(objectMapper);
-            private final MappingProvider mappingProvider = new JacksonMappingProvider(objectMapper);
-
-            @Override
-            public JsonProvider jsonProvider() {
-                return jsonProvider;
-            }
-
-            @Override
-            public MappingProvider mappingProvider() {
-                return mappingProvider;
-            }
-
-            @Override
-            public Set<Option> options() {
-                return EnumSet.noneOf(Option.class);
-            }
-        });
         reportService.deleteAll();
         SQLStatementCountValidator.reset();
     }
@@ -165,6 +141,8 @@ public class ReportControllerTest {
         mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID))
             .andExpect(status().isOk())
             .andExpect(content().json(toString(EXPECTED_STRUCTURE_ONLY_REPORT1)));
+
+
 
         assertRequestsCount(3, 0, 0, 0);
     }

--- a/src/test/java/org/gridsuite/report/server/ReportControllerTest.java
+++ b/src/test/java/org/gridsuite/report/server/ReportControllerTest.java
@@ -6,19 +6,17 @@
  */
 package org.gridsuite.report.server;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.ByteStreams;
 import com.jayway.jsonpath.Configuration;
-import com.jayway.jsonpath.Option;
-import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
-import com.jayway.jsonpath.spi.json.JsonProvider;
-import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
-import com.jayway.jsonpath.spi.mapper.MappingProvider;
+import com.powsybl.commons.report.ReportNode;
 import com.vladmihalcea.sql.SQLStatementCountValidator;
 import lombok.SneakyThrows;
 import org.gridsuite.report.server.entities.TreeReportEntity;
 import org.gridsuite.report.server.repositories.TreeReportRepository;
+import org.gridsuite.report.server.utils.TestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,13 +28,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
-import static org.gridsuite.report.server.utils.TestUtils.assertRequestsCount;
+import static org.gridsuite.report.server.utils.TestUtils.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -109,9 +109,10 @@ public class ReportControllerTest {
         String testReport1 = toString(REPORT_ONE);
         insertReport(REPORT_UUID, testReport1);
 
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR"))
+        MvcResult result = mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR"))
             .andExpect(status().isOk())
-            .andExpect(content().json(toString(EXPECTED_SINGLE_REPORT)));
+            .andReturn();
+        assertReportListsAreEqualIgnoringIds(result, toString(EXPECTED_SINGLE_REPORT));
 
         insertReport(REPORT_UUID, toString(REPORT_TWO));
 
@@ -124,9 +125,10 @@ public class ReportControllerTest {
 
         mvc.perform(delete(URL_TEMPLATE + "/reports/" + REPORT_UUID)).andExpect(status().isNotFound());
 
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true"))
-                .andExpect(content().json(toString(DEFAULT_EMPTY_REPORT1)))
-                .andExpect(status().isOk());
+        MvcResult resultAfterDeletion = mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true"))
+                .andExpect(status().isOk())
+                .andReturn();
+        assertReportListsAreEqualIgnoringIds(resultAfterDeletion, toString(DEFAULT_EMPTY_REPORT1));
     }
 
     @Test
@@ -138,12 +140,11 @@ public class ReportControllerTest {
         assertRequestsCount(2, 6, 0, 0);
         SQLStatementCountValidator.reset();
 
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID))
+        MvcResult result = mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID))
             .andExpect(status().isOk())
-            .andExpect(content().json(toString(EXPECTED_STRUCTURE_ONLY_REPORT1)));
+            .andReturn();
 
-
-
+        assertReportListsAreEqualIgnoringIds(result, toString(EXPECTED_STRUCTURE_ONLY_REPORT1));
         assertRequestsCount(3, 0, 0, 0);
     }
 
@@ -154,11 +155,11 @@ public class ReportControllerTest {
 
         SQLStatementCountValidator.reset();
 
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR"))
+        MvcResult result = mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR"))
             .andExpect(status().isOk())
-            .andExpect(content().json(toString(EXPECTED_STRUCTURE_AND_ELEMENTS_REPORT1)))
             .andReturn();
 
+        assertReportListsAreEqualIgnoringIds(result, toString(EXPECTED_STRUCTURE_AND_ELEMENTS_REPORT1));
         assertRequestsCount(4, 0, 0, 0);
     }
 
@@ -169,10 +170,11 @@ public class ReportControllerTest {
 
         SQLStatementCountValidator.reset();
         final String filterValue = "roundTripReporterJsonTest";
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR&reportNameFilter=" + filterValue + "&reportNameMatchingType=EXACT_MATCHING"))
-                .andExpect(status().isOk())
-                .andExpect(content().json(toString(EXPECTED_STRUCTURE_AND_ELEMENTS_REPORT1)));
+        MvcResult result = mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR&reportNameFilter=" + filterValue + "&reportNameMatchingType=EXACT_MATCHING"))
+            .andExpect(status().isOk())
+            .andReturn();
 
+        assertReportListsAreEqualIgnoringIds(result, toString(EXPECTED_STRUCTURE_AND_ELEMENTS_REPORT1));
         assertRequestsCount(4, 0, 0, 0);
     }
 
@@ -183,10 +185,11 @@ public class ReportControllerTest {
 
         SQLStatementCountValidator.reset();
         final String filterValue = "__noMatchingValue__";
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&reportNameFilter=" + filterValue + "&reportNameMatchingType=EXACT_MATCHING"))
+        MvcResult result = mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&reportNameFilter=" + filterValue + "&reportNameMatchingType=EXACT_MATCHING"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(toString(DEFAULT_EMPTY_REPORT1)));
+                .andReturn();
 
+        assertReportListsAreEqualIgnoringIds(result, toString(DEFAULT_EMPTY_REPORT1));
         assertRequestsCount(2, 0, 0, 0);
     }
 
@@ -197,10 +200,11 @@ public class ReportControllerTest {
 
         SQLStatementCountValidator.reset();
         final String filterEndsWithValue = "ReporterJsonTest";
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR&reportNameFilter=" + filterEndsWithValue + "&reportNameMatchingType=ENDS_WITH"))
+        MvcResult result = mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR&reportNameFilter=" + filterEndsWithValue + "&reportNameMatchingType=ENDS_WITH"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(toString(EXPECTED_STRUCTURE_AND_ELEMENTS_REPORT1)));
+                .andReturn();
 
+        assertReportListsAreEqualIgnoringIds(result, toString(EXPECTED_STRUCTURE_AND_ELEMENTS_REPORT1));
         assertRequestsCount(4, 0, 0, 0);
     }
 
@@ -212,10 +216,11 @@ public class ReportControllerTest {
         SQLStatementCountValidator.reset();
         final String filterEndsWithValue = "__noMatchingValue__";
 
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&reportNameFilter=" + filterEndsWithValue + "&reportNameMatchingType=ENDS_WITH"))
+        MvcResult result = mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&reportNameFilter=" + filterEndsWithValue + "&reportNameMatchingType=ENDS_WITH"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(toString(DEFAULT_EMPTY_REPORT1)));
+                .andReturn();
 
+        assertReportListsAreEqualIgnoringIds(result, toString(DEFAULT_EMPTY_REPORT1));
         assertRequestsCount(2, 0, 0, 0);
     }
 
@@ -225,11 +230,11 @@ public class ReportControllerTest {
         insertReport(REPORT_UUID, testReport1);
 
         SQLStatementCountValidator.reset();
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true"))
+        MvcResult result = mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(toString(EXPECTED_STRUCTURE_AND_NO_REPORT_ELEMENT)))
                 .andReturn();
 
+        assertReportListsAreEqualIgnoringIds(result, toString(EXPECTED_STRUCTURE_AND_NO_REPORT_ELEMENT));
         assertRequestsCount(4, 0, 0, 0);
     }
 
@@ -239,11 +244,11 @@ public class ReportControllerTest {
         insertReport(REPORT_UUID, testReport1);
 
         SQLStatementCountValidator.reset();
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&severityLevels=ERROR"))
+        MvcResult result = mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&severityLevels=ERROR"))
             .andExpect(status().isOk())
-            .andExpect(content().json(toString(EXPECTED_STRUCTURE_AND_ELEMENTS_REPORT1_ONLY_WITH_ERRORS)))
             .andReturn();
 
+        assertReportListsAreEqualIgnoringIds(result, toString(EXPECTED_STRUCTURE_AND_ELEMENTS_REPORT1_ONLY_WITH_ERRORS));
         assertRequestsCount(4, 0, 0, 0);
     }
 
@@ -253,11 +258,11 @@ public class ReportControllerTest {
         insertReport(REPORT_UUID, testReport1);
 
         SQLStatementCountValidator.reset();
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&severityLevels=INFO"))
+        MvcResult result = mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&severityLevels=INFO"))
             .andExpect(status().isOk())
-            .andExpect(content().json(toString(EXPECTED_STRUCTURE_AND_ELEMENTS_REPORT1_ONLY_WITH_INFOS)))
             .andReturn();
 
+        assertReportListsAreEqualIgnoringIds(result, toString(EXPECTED_STRUCTURE_AND_ELEMENTS_REPORT1_ONLY_WITH_INFOS));
         assertRequestsCount(4, 0, 0, 0);
     }
 
@@ -272,10 +277,11 @@ public class ReportControllerTest {
 
         SQLStatementCountValidator.reset();
 
-        mvc.perform(get(URL_TEMPLATE + "/subreports/" + uuidReporter + "?severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR"))
+        MvcResult result = mvc.perform(get(URL_TEMPLATE + "/subreports/" + uuidReporter + "?severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR"))
             .andExpect(status().isOk())
-            .andExpect(content().json(toString(EXPECTED_STRUCTURE_AND_ELEMENTS_REPORTER1)));
+            .andReturn();
 
+        assertReportListsAreEqualIgnoringIds(result, toString(EXPECTED_STRUCTURE_AND_ELEMENTS_REPORTER1));
         assertRequestsCount(3, 0, 0, 0);
     }
 
@@ -290,23 +296,27 @@ public class ReportControllerTest {
 
         SQLStatementCountValidator.reset();
 
-        mvc.perform(get(URL_TEMPLATE + "/subreports/" + uuidReporter))
+        MvcResult result = mvc.perform(get(URL_TEMPLATE + "/subreports/" + uuidReporter))
                 .andExpect(status().isOk())
-                .andExpect(content().json(toString(EXPECTED_STRUCTURE_AND_NO_REPORTER_ELEMENT)));
+                .andReturn();
 
+        assertReportListsAreEqualIgnoringIds(result, toString(EXPECTED_STRUCTURE_AND_NO_REPORTER_ELEMENT));
         assertRequestsCount(3, 0, 0, 0);
     }
 
     @SneakyThrows
     @Test
     public void testDefaultEmptyReport() {
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID))
+        MvcResult result1 = mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID))
             .andExpect(status().isOk())
-            .andExpect(content().json(toString(DEFAULT_EMPTY_REPORT1)));
+            .andReturn();
+        assertReportListsAreEqualIgnoringIds(result1, toString(DEFAULT_EMPTY_REPORT1));
 
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?defaultName=test"))
+        MvcResult result2 = mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?defaultName=test"))
             .andExpect(status().isOk())
-            .andExpect(content().json(toString(DEFAULT_EMPTY_REPORT2)));
+            .andReturn();
+        assertReportListsAreEqualIgnoringIds(result2, toString(DEFAULT_EMPTY_REPORT2));
+
     }
 
     @Test
@@ -378,9 +388,10 @@ public class ReportControllerTest {
     }
 
     private void testImported(String report1Id, String reportConcat2) throws Exception {
-        mvc.perform(get(URL_TEMPLATE + "/reports/" + report1Id + "?withElements=true&severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR"))
+        MvcResult result = mvc.perform(get(URL_TEMPLATE + "/reports/" + report1Id + "?withElements=true&severityLevels=INFO&severityLevels=TRACE&severityLevels=ERROR"))
             .andExpect(status().isOk())
-            .andExpect(content().json(toString(reportConcat2)));
+            .andReturn();
+        assertReportListsAreEqualIgnoringIds(result, toString(reportConcat2));
     }
 
     private void insertReport(String reportsId, String content) throws Exception {
@@ -390,4 +401,9 @@ public class ReportControllerTest {
             .andExpect(status().isOk());
     }
 
+    private void assertReportListsAreEqualIgnoringIds(MvcResult result, String expectedContent) throws JsonProcessingException, UnsupportedEncodingException {
+        List<ReportNode> expectedReportNodeList = objectMapper.readValue(expectedContent, new TypeReference<>() { });
+        List<ReportNode> actualReportNodeList = objectMapper.readValue(result.getResponse().getContentAsString(), new TypeReference<>() { });
+        TestUtils.assertReportListsAreEqualIgnoringIds(expectedReportNodeList, actualReportNodeList);
+    }
 }

--- a/src/test/java/org/gridsuite/report/server/ReportControllerTest.java
+++ b/src/test/java/org/gridsuite/report/server/ReportControllerTest.java
@@ -111,6 +111,8 @@ public class ReportControllerTest {
     private static final String EXPECTED_SINGLE_REPORT = "/expectedSingleReport.json";
     private static final String EXPECTED_STRUCTURE_ONLY_REPORT1 = "/expectedStructureOnlyReportOne.json";
     private static final String EXPECTED_STRUCTURE_AND_ELEMENTS_REPORT1 = "/expectedStructureAndElementsReportOne.json";
+    private static final String EXPECTED_STRUCTURE_AND_ELEMENTS_REPORT1_ONLY_WITH_ERRORS = "/expectedStructureAndElementsReportOneWithOnlyErrors.json";
+    private static final String EXPECTED_STRUCTURE_AND_ELEMENTS_REPORT1_ONLY_WITH_INFOS = "/expectedStructureAndElementsReportOneWithOnlyInfos.json";
     private static final String EXPECTED_STRUCTURE_AND_NO_REPORT_ELEMENT = "/expectedStructureAndNoElementReportOne.json";
     private static final String EXPECTED_STRUCTURE_AND_ELEMENTS_REPORTER1 = "/expectedReporterAndElements.json";
     private static final String EXPECTED_STRUCTURE_AND_NO_REPORTER_ELEMENT = "/expectedReporterAndNoElement.json";
@@ -249,6 +251,34 @@ public class ReportControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().json(toString(EXPECTED_STRUCTURE_AND_NO_REPORT_ELEMENT)))
                 .andReturn();
+
+        assertRequestsCount(4, 0, 0, 0);
+    }
+
+    @Test
+    public void testGetReportWithSeverityFiltersOnError() throws Exception {
+        String testReport1 = toString(REPORT_ONE);
+        insertReport(REPORT_UUID, testReport1);
+
+        SQLStatementCountValidator.reset();
+        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&severityLevels=ERROR"))
+            .andExpect(status().isOk())
+            .andExpect(content().json(toString(EXPECTED_STRUCTURE_AND_ELEMENTS_REPORT1_ONLY_WITH_ERRORS)))
+            .andReturn();
+
+        assertRequestsCount(4, 0, 0, 0);
+    }
+
+    @Test
+    public void testGetReportWithSeverityFiltersOnInfo() throws Exception {
+        String testReport1 = toString(REPORT_ONE);
+        insertReport(REPORT_UUID, testReport1);
+
+        SQLStatementCountValidator.reset();
+        mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID + "?withElements=true&severityLevels=INFO"))
+            .andExpect(status().isOk())
+            .andExpect(content().json(toString(EXPECTED_STRUCTURE_AND_ELEMENTS_REPORT1_ONLY_WITH_INFOS)))
+            .andReturn();
 
         assertRequestsCount(4, 0, 0, 0);
     }

--- a/src/test/java/org/gridsuite/report/server/utils/TestUtils.java
+++ b/src/test/java/org/gridsuite/report/server/utils/TestUtils.java
@@ -49,29 +49,29 @@ public final class TestUtils {
         return entity;
     }
 
-    public static void assertReportsAreEqualIgnoringIds(ReportNode node1, ReportNode node2) {
-        assertEquals(node2.getMessageKey(), node1.getMessageKey());
-        assertEquals(node2.getMessageTemplate(), node1.getMessageTemplate());
-        assertEquals(node2.getValues().size(), node1.getValues().size());
-        for (var entry : node2.getValues().entrySet()) {
-            TypedValue value = node1.getValues().getOrDefault(entry.getKey(), null);
-            assertNotNull(value);
-            assertEquals(entry.getValue().getType(), value.getType());
-            if (entry.getKey().equals("id")) {
+    public static void assertReportsAreEqualIgnoringIds(ReportNode expectedNode, ReportNode actualNode) {
+        assertEquals(expectedNode.getMessageKey(), actualNode.getMessageKey());
+        assertEquals(expectedNode.getMessageTemplate(), actualNode.getMessageTemplate());
+        assertEquals(expectedNode.getValues().size(), actualNode.getValues().size());
+        for (var actualNodeEntry : actualNode.getValues().entrySet()) {
+            TypedValue expectedValue = expectedNode.getValues().getOrDefault(actualNodeEntry.getKey(), null);
+            assertNotNull(expectedValue);
+            assertEquals(expectedValue.getType(), actualNodeEntry.getValue().getType());
+            if (actualNodeEntry.getKey().equals("id")) {
                 continue;
             }
-            assertEquals(entry.getValue().getValue(), value.getValue());
+            assertEquals(expectedValue.getValue(), actualNodeEntry.getValue().getValue());
         }
-        assertEquals(node1.getChildren().size(), node2.getChildren().size());
-        for (int i = 0; i < node1.getChildren().size(); i++) {
-            assertReportsAreEqualIgnoringIds(node1.getChildren().get(i), node2.getChildren().get(i));
+        assertEquals(expectedNode.getChildren().size(), actualNode.getChildren().size());
+        for (int i = 0; i < expectedNode.getChildren().size(); i++) {
+            assertReportsAreEqualIgnoringIds(expectedNode.getChildren().get(i), actualNode.getChildren().get(i));
         }
     }
 
-    public static void assertReportListsAreEqualIgnoringIds(List<ReportNode> nodeList1, List<ReportNode> nodeList2) {
-        assertEquals(nodeList1.size(), nodeList2.size());
-        for (int i = 0; i < nodeList1.size(); i++) {
-            assertReportsAreEqualIgnoringIds(nodeList1.get(i), nodeList2.get(i));
+    public static void assertReportListsAreEqualIgnoringIds(List<ReportNode> expectedNodeList, List<ReportNode> actualNodeList) {
+        assertEquals(expectedNodeList.size(), actualNodeList.size());
+        for (int i = 0; i < expectedNodeList.size(); i++) {
+            assertReportsAreEqualIgnoringIds(expectedNodeList.get(i), actualNodeList.get(i));
         }
     }
 }

--- a/src/test/java/org/gridsuite/report/server/utils/TestUtils.java
+++ b/src/test/java/org/gridsuite/report/server/utils/TestUtils.java
@@ -7,15 +7,20 @@
 
 package org.gridsuite.report.server.utils;
 
+import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.TypedValue;
 import org.gridsuite.report.server.entities.ReportEntity;
 import org.gridsuite.report.server.entities.TreeReportEntity;
 
+import java.util.List;
 import java.util.Map;
 
 import static com.vladmihalcea.sql.SQLStatementCountValidator.assertDeleteCount;
 import static com.vladmihalcea.sql.SQLStatementCountValidator.assertInsertCount;
 import static com.vladmihalcea.sql.SQLStatementCountValidator.assertSelectCount;
 import static com.vladmihalcea.sql.SQLStatementCountValidator.assertUpdateCount;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public final class TestUtils {
 
@@ -42,5 +47,31 @@ public final class TestUtils {
                 "log3", "log3")
         );
         return entity;
+    }
+
+    public static void assertReportsAreEqualIgnoringIds(ReportNode node1, ReportNode node2) {
+        assertEquals(node2.getMessageKey(), node1.getMessageKey());
+        assertEquals(node2.getMessageTemplate(), node1.getMessageTemplate());
+        assertEquals(node2.getValues().size(), node1.getValues().size());
+        for (var entry : node2.getValues().entrySet()) {
+            TypedValue value = node1.getValues().getOrDefault(entry.getKey(), null);
+            assertNotNull(value);
+            assertEquals(entry.getValue().getType(), value.getType());
+            if (entry.getKey().equals("id")) {
+                continue;
+            }
+            assertEquals(entry.getValue().getValue(), value.getValue());
+        }
+        assertEquals(node1.getChildren().size(), node2.getChildren().size());
+        for (int i = 0; i < node1.getChildren().size(); i++) {
+            assertReportsAreEqualIgnoringIds(node1.getChildren().get(i), node2.getChildren().get(i));
+        }
+    }
+
+    public static void assertReportListsAreEqualIgnoringIds(List<ReportNode> nodeList1, List<ReportNode> nodeList2) {
+        assertEquals(nodeList1.size(), nodeList2.size());
+        for (int i = 0; i < nodeList1.size(); i++) {
+            assertReportsAreEqualIgnoringIds(nodeList1.get(i), nodeList2.get(i));
+        }
     }
 }

--- a/src/test/resources/expectedReporterAndElements.json
+++ b/src/test/resources/expectedReporterAndElements.json
@@ -1,107 +1,110 @@
 [
-    {
-        "version": "2.0",
-        "reportRoot":
-        {
-            "messageKey": "UcteReading",
-            "children":
-            [
-                {
-                    "messageKey": "fixUcteLines",
-                    "children":
-                    [
-                        {
-                            "messageKey": "negativeLineResistance",
-                            "values":
-                            {
-                                "reportSeverity":
-                                {
-                                    "value": "ERROR",
-                                    "type": "SEVERITY"
-                                },
-                                "lineId":
-                                {
-                                    "value": "FFFFFF11 XXXXXX11 1"
-                                },
-                                "resistance":
-                                {
-                                    "value": 0,
-                                    "type": "RESISTANCE"
-                                }
-                            }
-                        },
-                        {
-                            "messageKey": "negativeLineResistance",
-                            "values":
-                            {
-                                "reportSeverity":
-                                {
-                                    "value": "ERROR",
-                                    "type": "SEVERITY"
-                                },
-                                "lineId":
-                                {
-                                    "value": "FFFFFF11 XXXXXX12 1"
-                                },
-                                "resistance":
-                                {
-                                    "value": 0.0,
-                                    "type": "RESISTANCE"
-                                }
-                            }
-                        },
-                        {
-                            "messageKey": "negativeLineResistance",
-                            "values":
-                            {
-                                "reportSeverity":
-                                {
-                                    "value": "ERROR",
-                                    "type": "SEVERITY"
-                                },
-                                "lineId":
-                                {
-                                    "value": "FFFFFF13 XXXXXX13 1"
-                                },
-                                "resistance":
-                                {
-                                    "value": 0.0,
-                                    "type": "RESISTANCE"
-                                }
-                            }
-                        },
-                        {
-                            "messageKey": "negativeLineResistance",
-                            "values":
-                            {
-                                "reportSeverity":
-                                {
-                                    "value": "ERROR",
-                                    "type": "SEVERITY"
-                                },
-                                "lineId":
-                                {
-                                    "value": "FFFFFF13 XXXXXX14 1"
-                                },
-                                "resistance":
-                                {
-                                    "value": 0.0,
-                                    "type": "RESISTANCE"
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "dictionaries":
-            {
-                "default":
-                {
-                    "UcteReading": "Reading UCTE network file",
-                    "fixUcteLines": "Fix UCTE lines",
-                    "negativeLineResistance": "${lineId} - Real line resistance cannot be negative (${resistance} ohm)"
-                }
-            }
+  {
+    "version": "2.0",
+    "reportRoot": {
+      "messageKey": "UcteReading",
+      "values": {
+        "severityList": {
+          "value": "[]",
+          "type": "SEVERITY"
         }
+      },
+      "children": [
+        {
+          "messageKey": "fixUcteLines",
+          "values": {
+            "severityList": {
+              "value": "[ERROR]",
+              "type": "SEVERITY"
+            }
+          },
+          "children": [
+            {
+              "messageKey": "negativeLineResistance",
+              "values": {
+                "reportSeverity": {
+                  "value": "ERROR",
+                  "type": "SEVERITY"
+                },
+                "lineId": {
+                  "value": "FFFFFF11 XXXXXX11 1"
+                },
+                "resistance": {
+                  "value": 0,
+                  "type": "RESISTANCE"
+                }
+              }
+            },
+            {
+              "messageKey": "negativeLineResistance",
+              "values": {
+                "reportSeverity": {
+                  "value": "ERROR",
+                  "type": "SEVERITY"
+                },
+                "lineId": {
+                  "value": "FFFFFF11 XXXXXX12 1"
+                },
+                "resistance": {
+                  "value": 0,
+                  "type": "RESISTANCE"
+                }
+              }
+            },
+            {
+              "messageKey": "negativeLineResistance",
+              "values": {
+                "reportSeverity": {
+                  "value": "ERROR",
+                  "type": "SEVERITY"
+                },
+                "lineId": {
+                  "value": "FFFFFF13 XXXXXX13 1"
+                },
+                "resistance": {
+                  "value": 0,
+                  "type": "RESISTANCE"
+                }
+              }
+            },
+            {
+              "messageKey": "negativeLineResistance",
+              "values": {
+                "reportSeverity": {
+                  "value": "ERROR",
+                  "type": "SEVERITY"
+                },
+                "lineId": {
+                  "value": "FFFFFF13 XXXXXX14 1"
+                },
+                "resistance": {
+                  "value": 0,
+                  "type": "RESISTANCE"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "messageKey": "fixUcteNodes"
+        },
+        {
+          "messageKey": "fixUcteTransformer"
+        },
+        {
+          "messageKey": "fixUcteRegulations"
+        }
+      ],
+      "dictionaries": {
+        "default": {
+          "UcteReading": "Reading UCTE network file",
+          "fixUcteLines": "Fix UCTE lines",
+          "fixUcteNodes": "Fix UCTE nodes",
+          "fixUcteRegulations": "Fix UCTE regulations",
+          "fixUcteTransformer": "Fix UCTE transformers",
+          "negativeLineResistance": "${lineId} - Real line resistance cannot be negative (${resistance} ohm)"
+        }
+      }
     }
+  }
 ]

--- a/src/test/resources/expectedReporterAndElements.json
+++ b/src/test/resources/expectedReporterAndElements.json
@@ -7,6 +7,10 @@
         "severityList": {
           "value": "[]",
           "type": "SEVERITY"
+        },
+        "id": {
+          "value": "593a8546-bc05-4b53-b8d9-a2caf0e2f0f8",
+          "type": "ID"
         }
       },
       "children": [
@@ -16,6 +20,9 @@
             "severityList": {
               "value": "[ERROR]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "641a7c9b-5ed3-47bd-9d58-6a248a1d7621"
             }
           },
           "children": [
@@ -86,17 +93,33 @@
           ]
         },
         {
-          "messageKey": "fixUcteNodes"
+          "messageKey": "fixUcteNodes",
+          "values": {
+            "id": {
+              "value": "8345715b-127a-4922-a84c-fdab7a0433ef"
+            }
+          }
         },
         {
-          "messageKey": "fixUcteTransformer"
+          "messageKey": "fixUcteTransformer",
+          "values": {
+            "id": {
+              "value": "789de7bc-6228-4798-aaca-19e701548f53"
+            }
+          }
         },
         {
-          "messageKey": "fixUcteRegulations"
+          "messageKey": "fixUcteRegulations",
+          "values": {
+            "id": {
+              "value": "c5798b8c-a1cc-4be7-ba45-e938c1c130a4"
+            }
+          }
         }
       ],
       "dictionaries": {
         "default": {
+          "593a8546-bc05-4b53-b8d9-a2caf0e2f0f8": "593a8546-bc05-4b53-b8d9-a2caf0e2f0f8",
           "UcteReading": "Reading UCTE network file",
           "fixUcteLines": "Fix UCTE lines",
           "fixUcteNodes": "Fix UCTE nodes",

--- a/src/test/resources/expectedReporterAndNoElement.json
+++ b/src/test/resources/expectedReporterAndNoElement.json
@@ -1,16 +1,66 @@
 [
-    {
-        "version": "2.0",
-        "reportRoot":
-        {
-            "messageKey": "UcteReading",
-            "dictionaries":
-            {
-                "default":
-                {
-                    "UcteReading": "Reading UCTE network file"
-                }
-            }
+  {
+    "version": "2.0",
+    "reportRoot": {
+      "messageKey": "UcteReading",
+      "values": {
+        "severityList": {
+          "value": "[]",
+          "type": "SEVERITY"
+        },
+        "id": {
+          "value": "e8a61121-771c-4da3-990c-6e9f6d1b49de",
+          "type": "ID"
         }
+      },
+      "children": [
+        {
+          "messageKey": "fixUcteLines",
+          "values": {
+            "severityList": {
+              "value": "[ERROR]",
+              "type": "SEVERITY"
+            },
+            "id": {
+              "value": "3208c766-c386-4f27-8bed-8dee491fed8a"
+            }
+          }
+        },
+        {
+          "messageKey": "fixUcteNodes",
+          "values": {
+            "id": {
+              "value": "341f2b82-e5b1-4606-80d5-714996acee37"
+            }
+          }
+        },
+        {
+          "messageKey": "fixUcteTransformer",
+          "values": {
+            "id": {
+              "value": "8f3fbb49-6b1c-4e34-acb0-22eb2faad5b3"
+            }
+          }
+        },
+        {
+          "messageKey": "fixUcteRegulations",
+          "values": {
+            "id": {
+              "value": "e31a83ac-485e-482a-84bf-355718c09c6c"
+            }
+          }
+        }
+      ],
+      "dictionaries": {
+        "default": {
+          "UcteReading": "Reading UCTE network file",
+          "e8a61121-771c-4da3-990c-6e9f6d1b49de": "e8a61121-771c-4da3-990c-6e9f6d1b49de",
+          "fixUcteLines": "Fix UCTE lines",
+          "fixUcteNodes": "Fix UCTE nodes",
+          "fixUcteRegulations": "Fix UCTE regulations",
+          "fixUcteTransformer": "Fix UCTE transformers"
+        }
+      }
     }
+  }
 ]

--- a/src/test/resources/expectedSingleReport.json
+++ b/src/test/resources/expectedSingleReport.json
@@ -7,6 +7,10 @@
         "severityList": {
           "value": "[INFO, TRACE]",
           "type": "SEVERITY"
+        },
+        "id": {
+          "value": "b1ccc3ce-2682-448f-937d-4177a552d7fe",
+          "type": "ID"
         }
       },
       "children": [
@@ -16,6 +20,9 @@
             "severityList": {
               "value": "[]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "b6386ee3-437e-4d69-b0d3-04d2c54342ba"
             }
           },
           "children": [
@@ -25,6 +32,9 @@
                 "severityList": {
                   "value": "[ERROR]",
                   "type": "SEVERITY"
+                },
+                "id": {
+                  "value": "ca8c3a40-dcd3-4c66-be1e-a14df59ec108"
                 }
               },
               "children": [
@@ -95,13 +105,28 @@
               ]
             },
             {
-              "messageKey": "fixUcteNodes"
+              "messageKey": "fixUcteNodes",
+              "values": {
+                "id": {
+                  "value": "728f8222-b547-4d85-9230-5cdf0c78cf7e"
+                }
+              }
             },
             {
-              "messageKey": "fixUcteTransformer"
+              "messageKey": "fixUcteTransformer",
+              "values": {
+                "id": {
+                  "value": "1dfd6325-0450-46d6-aef3-cf12f94e75e8"
+                }
+              }
             },
             {
-              "messageKey": "fixUcteRegulations"
+              "messageKey": "fixUcteRegulations",
+              "values": {
+                "id": {
+                  "value": "c1185acb-2bea-4805-900d-2641facd0810"
+                }
+              }
             }
           ]
         },
@@ -111,6 +136,9 @@
             "severityList": {
               "value": "[]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "df2e0de8-0752-44ea-8576-488075a5f627"
             }
           },
           "children": [
@@ -123,6 +151,9 @@
                 "severityList": {
                   "value": "[TRACE]",
                   "type": "SEVERITY"
+                },
+                "id": {
+                  "value": "2fb29132-54cb-406d-9adc-065ae0aeba5f"
                 }
               },
               "children": [
@@ -186,6 +217,9 @@
             "severityList": {
               "value": "[TRACE]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "65ad1f55-8b63-4e27-8a61-bdd62ec70f1d"
             }
           },
           "children": [
@@ -272,6 +306,7 @@
       ],
       "dictionaries": {
         "default": {
+          "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13": "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13",
           "UcteReading": "Reading UCTE network file",
           "createBus": "Create bus ${bus}",
           "createBuses": "Create buses",

--- a/src/test/resources/expectedSingleReport.json
+++ b/src/test/resources/expectedSingleReport.json
@@ -3,21 +3,30 @@
     "version": "2.0",
     "reportRoot": {
       "messageKey": "roundTripReporterJsonTest",
+      "values": {
+        "severityList": {
+          "value": "[INFO, TRACE]",
+          "type": "SEVERITY"
+        }
+      },
       "children": [
         {
-          "messageKey": "novalueReport",
+          "messageKey": "UcteReading",
           "values": {
-            "reportSeverity": {
-              "value": "INFO",
+            "severityList": {
+              "value": "[]",
               "type": "SEVERITY"
             }
-          }
-        },
-        {
-          "messageKey": "UcteReading",
+          },
           "children": [
             {
               "messageKey": "fixUcteLines",
+              "values": {
+                "severityList": {
+                  "value": "[ERROR]",
+                  "type": "SEVERITY"
+                }
+              },
               "children": [
                 {
                   "messageKey": "negativeLineResistance",
@@ -46,7 +55,7 @@
                       "value": "FFFFFF11 XXXXXX12 1"
                     },
                     "resistance": {
-                      "value": 0.0,
+                      "value": 0,
                       "type": "RESISTANCE"
                     }
                   }
@@ -62,7 +71,7 @@
                       "value": "FFFFFF13 XXXXXX13 1"
                     },
                     "resistance": {
-                      "value": 0.0,
+                      "value": 0,
                       "type": "RESISTANCE"
                     }
                   }
@@ -78,23 +87,42 @@
                       "value": "FFFFFF13 XXXXXX14 1"
                     },
                     "resistance": {
-                      "value": 0.0,
+                      "value": 0,
                       "type": "RESISTANCE"
                     }
                   }
                 }
               ]
+            },
+            {
+              "messageKey": "fixUcteNodes"
+            },
+            {
+              "messageKey": "fixUcteTransformer"
+            },
+            {
+              "messageKey": "fixUcteRegulations"
             }
           ]
         },
         {
           "messageKey": "createBuses",
+          "values": {
+            "severityList": {
+              "value": "[]",
+              "type": "SEVERITY"
+            }
+          },
           "children": [
             {
               "messageKey": "createBusesSubstation",
               "values": {
                 "substation": {
                   "value": "FFFFFF"
+                },
+                "severityList": {
+                  "value": "[TRACE]",
+                  "type": "SEVERITY"
                 }
               },
               "children": [
@@ -154,6 +182,12 @@
         },
         {
           "messageKey": "createLines",
+          "values": {
+            "severityList": {
+              "value": "[TRACE]",
+              "type": "SEVERITY"
+            }
+          },
           "children": [
             {
               "messageKey": "danglingLineCreation",
@@ -218,24 +252,42 @@
           ]
         },
         {
-          "messageKey": "createTransformers"
+          "messageKey": "novalueReport",
+          "values": {
+            "reportSeverity": {
+              "value": "INFO",
+              "type": "SEVERITY"
+            }
+          }
+        },
+        {
+          "messageKey": "createTransformers",
+          "values": {
+            "reportSeverity": {
+              "value": "TRACE",
+              "type": "SEVERITY"
+            }
+          }
         }
       ],
       "dictionaries": {
         "default": {
           "UcteReading": "Reading UCTE network file",
-          "createLines": "Create lines",
-          "createSubstation": "Create substation ${substationName}",
-          "novalueReport": "No value report",
-          "createTransformers": "Create transformers",
-          "roundTripReporterJsonTest": "Test importing UCTE file frVoltageRegulatingXnode.uct",
-          "createBusesSubstation": "Create buses for substation ${substation}",
           "createBus": "Create bus ${bus}",
           "createBuses": "Create buses",
-          "danglingLineCreation": "Create dangling line '${ucteLine}' (Xnode='${xnodeCode}')",
+          "createBusesSubstation": "Create buses for substation ${substation}",
+          "createLines": "Create lines",
+          "createSubstation": "Create substation ${substationName}",
+          "createTransformers": "Create transformers",
           "createVoltageLevel": "Create voltage level ${voltageLevelName}",
+          "danglingLineCreation": "Create dangling line '${ucteLine}' (Xnode='${xnodeCode}')",
           "fixUcteLines": "Fix UCTE lines",
-          "negativeLineResistance": "${lineId} - Real line resistance cannot be negative (${resistance} ohm)"
+          "fixUcteNodes": "Fix UCTE nodes",
+          "fixUcteRegulations": "Fix UCTE regulations",
+          "fixUcteTransformer": "Fix UCTE transformers",
+          "negativeLineResistance": "${lineId} - Real line resistance cannot be negative (${resistance} ohm)",
+          "novalueReport": "No value report",
+          "roundTripReporterJsonTest": "Test importing UCTE file frVoltageRegulatingXnode.uct"
         }
       }
     }

--- a/src/test/resources/expectedStructureAndElementsReportOne.json
+++ b/src/test/resources/expectedStructureAndElementsReportOne.json
@@ -1,250 +1,295 @@
 [
-    {
-        "version": "2.0",
-        "reportRoot": {
-            "messageKey": "roundTripReporterJsonTest",
-            "children": [
-                {
-                    "messageKey": "novalueReport",
-                    "values": {
-                        "reportSeverity" : {
-                            "value" : "INFO",
-                            "type": "SEVERITY"
-                        }
-                    }
-                },
-                {
-                    "messageKey": "UcteReading",
-                    "children": [
-                        {
-                            "messageKey": "fixUcteLines",
-                            "children": [
-                                {
-                                    "messageKey": "negativeLineResistance",
-                                    "values": {
-                                        "reportSeverity": {
-                                            "value": "ERROR",
-                                            "type": "SEVERITY"
-                                        },
-                                        "lineId": {
-                                            "value": "FFFFFF11 XXXXXX11 1"
-                                        },
-                                        "resistance": {
-                                            "value": 0,
-                                            "type": "RESISTANCE"
-                                        }
-                                    }
-                                },
-                                {
-                                    "messageKey": "negativeLineResistance",
-                                    "values": {
-                                        "reportSeverity": {
-                                            "value": "ERROR",
-                                            "type": "SEVERITY"
-                                        },
-                                        "lineId": {
-                                            "value": "FFFFFF11 XXXXXX12 1"
-                                        },
-                                        "resistance": {
-                                            "value": 0.0,
-                                            "type": "RESISTANCE"
-                                        }
-                                    }
-                                },
-                                {
-                                    "messageKey": "negativeLineResistance",
-                                    "values": {
-                                        "reportSeverity": {
-                                            "value": "ERROR",
-                                            "type": "SEVERITY"
-                                        },
-                                        "lineId": {
-                                            "value": "FFFFFF13 XXXXXX13 1"
-                                        },
-                                        "resistance": {
-                                            "value": 0.0,
-                                            "type": "RESISTANCE"
-                                        }
-                                    }
-                                },
-                                {
-                                    "messageKey": "negativeLineResistance",
-                                    "values": {
-                                        "reportSeverity": {
-                                            "value": "ERROR",
-                                            "type": "SEVERITY"
-                                        },
-                                        "lineId": {
-                                            "value": "FFFFFF13 XXXXXX14 1"
-                                        },
-                                        "resistance": {
-                                            "value": 0.0,
-                                            "type": "RESISTANCE"
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "messageKey": "createBuses",
-                    "children": [
-                        {
-                            "messageKey": "createBusesSubstation",
-                            "values": {
-                                "substation": {
-                                    "value": "FFFFFF"
-                                }
-                            },
-                            "children": [
-                                {
-                                    "messageKey": "createSubstation",
-                                    "values": {
-                                        "reportSeverity": {
-                                            "value": "TRACE",
-                                            "type": "SEVERITY"
-                                        },
-                                        "substationName": {
-                                            "value": "FFFFFF",
-                                            "type": "SUBSTATION"
-                                        }
-                                    }
-                                },
-                                {
-                                    "messageKey": "createVoltageLevel",
-                                    "values": {
-                                        "voltageLevelName": {
-                                            "value": "FFFFFF1",
-                                            "type": "VOLTAGE_LEVEL"
-                                        },
-                                        "reportSeverity": {
-                                            "value": "TRACE",
-                                            "type": "SEVERITY"
-                                        }
-                                    }
-                                },
-                                {
-                                    "messageKey": "createBus",
-                                    "values": {
-                                        "bus": {
-                                            "value": "FFFFFF11"
-                                        },
-                                        "reportSeverity": {
-                                            "value": "TRACE",
-                                            "type": "SEVERITY"
-                                        }
-                                    }
-                                },
-                                {
-                                    "messageKey": "createBus",
-                                    "values": {
-                                        "bus": {
-                                            "value": "FFFFFF13"
-                                        },
-                                        "reportSeverity": {
-                                            "value": "TRACE",
-                                            "type": "SEVERITY"
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "messageKey": "createLines",
-                    "children": [
-                        {
-                            "messageKey": "danglingLineCreation",
-                            "values": {
-                                "ucteLine": {
-                                    "value": "FFFFFF11 XXXXXX11 1"
-                                },
-                                "reportSeverity": {
-                                    "value": "TRACE",
-                                    "type": "SEVERITY"
-                                },
-                                "xnodeCode": {
-                                    "value": "XXXXXX11"
-                                }
-                            }
-                        },
-                        {
-                            "messageKey": "danglingLineCreation",
-                            "values": {
-                                "ucteLine": {
-                                    "value": "FFFFFF11 XXXXXX12 1"
-                                },
-                                "reportSeverity": {
-                                    "value": "TRACE",
-                                    "type": "SEVERITY"
-                                },
-                                "xnodeCode": {
-                                    "value": "XXXXXX12"
-                                }
-                            }
-                        },
-                        {
-                            "messageKey": "danglingLineCreation",
-                            "values": {
-                                "ucteLine": {
-                                    "value": "FFFFFF13 XXXXXX13 1"
-                                },
-                                "reportSeverity": {
-                                    "value": "TRACE",
-                                    "type": "SEVERITY"
-                                },
-                                "xnodeCode": {
-                                    "value": "XXXXXX13"
-                                }
-                            }
-                        },
-                        {
-                            "messageKey": "danglingLineCreation",
-                            "values": {
-                                "ucteLine": {
-                                    "value": "FFFFFF13 XXXXXX14 1"
-                                },
-                                "reportSeverity": {
-                                    "value": "TRACE",
-                                    "type": "SEVERITY"
-                                },
-                                "xnodeCode": {
-                                    "value": "XXXXXX14"
-                                }
-                            }
-                        }
-                    ]
-                },
-                {
-                    "messageKey": "createTransformers",
-                    "values": {
-                        "reportSeverity": {
-                            "value": "TRACE",
-                            "type": "SEVERITY"
-                        }
-                    }
-                }
-            ],
-            "dictionaries": {
-                "default": {
-                    "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13": "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13",
-                    "UcteReading": "Reading UCTE network file",
-                    "createBus": "Create bus ${bus}",
-                    "createBuses": "Create buses",
-                    "createBusesSubstation": "Create buses for substation ${substation}",
-                    "createLines": "Create lines",
-                    "createSubstation": "Create substation ${substationName}",
-                    "createTransformers": "Create transformers",
-                    "createVoltageLevel": "Create voltage level ${voltageLevelName}",
-                    "danglingLineCreation": "Create dangling line '${ucteLine}' (Xnode='${xnodeCode}')",
-                    "fixUcteLines": "Fix UCTE lines",
-                    "negativeLineResistance": "${lineId} - Real line resistance cannot be negative (${resistance} ohm)",
-                    "novalueReport": "No value report",
-                    "roundTripReporterJsonTest": "Test importing UCTE file frVoltageRegulatingXnode.uct"
-                }
-            }
+  {
+    "version": "2.0",
+    "reportRoot": {
+      "messageKey": "roundTripReporterJsonTest",
+      "values": {
+        "severityList": {
+          "value": "[INFO, TRACE]",
+          "type": "SEVERITY"
         }
+      },
+      "children": [
+        {
+          "messageKey": "UcteReading",
+          "values": {
+            "severityList": {
+              "value": "[]",
+              "type": "SEVERITY"
+            }
+          },
+          "children": [
+            {
+              "messageKey": "fixUcteLines",
+              "values": {
+                "severityList": {
+                  "value": "[ERROR]",
+                  "type": "SEVERITY"
+                }
+              },
+              "children": [
+                {
+                  "messageKey": "negativeLineResistance",
+                  "values": {
+                    "reportSeverity": {
+                      "value": "ERROR",
+                      "type": "SEVERITY"
+                    },
+                    "lineId": {
+                      "value": "FFFFFF11 XXXXXX11 1"
+                    },
+                    "resistance": {
+                      "value": 0,
+                      "type": "RESISTANCE"
+                    }
+                  }
+                },
+                {
+                  "messageKey": "negativeLineResistance",
+                  "values": {
+                    "reportSeverity": {
+                      "value": "ERROR",
+                      "type": "SEVERITY"
+                    },
+                    "lineId": {
+                      "value": "FFFFFF11 XXXXXX12 1"
+                    },
+                    "resistance": {
+                      "value": 0,
+                      "type": "RESISTANCE"
+                    }
+                  }
+                },
+                {
+                  "messageKey": "negativeLineResistance",
+                  "values": {
+                    "reportSeverity": {
+                      "value": "ERROR",
+                      "type": "SEVERITY"
+                    },
+                    "lineId": {
+                      "value": "FFFFFF13 XXXXXX13 1"
+                    },
+                    "resistance": {
+                      "value": 0,
+                      "type": "RESISTANCE"
+                    }
+                  }
+                },
+                {
+                  "messageKey": "negativeLineResistance",
+                  "values": {
+                    "reportSeverity": {
+                      "value": "ERROR",
+                      "type": "SEVERITY"
+                    },
+                    "lineId": {
+                      "value": "FFFFFF13 XXXXXX14 1"
+                    },
+                    "resistance": {
+                      "value": 0,
+                      "type": "RESISTANCE"
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "messageKey": "fixUcteNodes"
+            },
+            {
+              "messageKey": "fixUcteTransformer"
+            },
+            {
+              "messageKey": "fixUcteRegulations"
+            }
+          ]
+        },
+        {
+          "messageKey": "createBuses",
+          "values": {
+            "severityList": {
+              "value": "[]",
+              "type": "SEVERITY"
+            }
+          },
+          "children": [
+            {
+              "messageKey": "createBusesSubstation",
+              "values": {
+                "substation": {
+                  "value": "FFFFFF"
+                },
+                "severityList": {
+                  "value": "[TRACE]",
+                  "type": "SEVERITY"
+                }
+              },
+              "children": [
+                {
+                  "messageKey": "createSubstation",
+                  "values": {
+                    "reportSeverity": {
+                      "value": "TRACE",
+                      "type": "SEVERITY"
+                    },
+                    "substationName": {
+                      "value": "FFFFFF",
+                      "type": "SUBSTATION"
+                    }
+                  }
+                },
+                {
+                  "messageKey": "createVoltageLevel",
+                  "values": {
+                    "voltageLevelName": {
+                      "value": "FFFFFF1",
+                      "type": "VOLTAGE_LEVEL"
+                    },
+                    "reportSeverity": {
+                      "value": "TRACE",
+                      "type": "SEVERITY"
+                    }
+                  }
+                },
+                {
+                  "messageKey": "createBus",
+                  "values": {
+                    "bus": {
+                      "value": "FFFFFF11"
+                    },
+                    "reportSeverity": {
+                      "value": "TRACE",
+                      "type": "SEVERITY"
+                    }
+                  }
+                },
+                {
+                  "messageKey": "createBus",
+                  "values": {
+                    "bus": {
+                      "value": "FFFFFF13"
+                    },
+                    "reportSeverity": {
+                      "value": "TRACE",
+                      "type": "SEVERITY"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "messageKey": "createLines",
+          "values": {
+            "severityList": {
+              "value": "[TRACE]",
+              "type": "SEVERITY"
+            }
+          },
+          "children": [
+            {
+              "messageKey": "danglingLineCreation",
+              "values": {
+                "ucteLine": {
+                  "value": "FFFFFF11 XXXXXX11 1"
+                },
+                "reportSeverity": {
+                  "value": "TRACE",
+                  "type": "SEVERITY"
+                },
+                "xnodeCode": {
+                  "value": "XXXXXX11"
+                }
+              }
+            },
+            {
+              "messageKey": "danglingLineCreation",
+              "values": {
+                "ucteLine": {
+                  "value": "FFFFFF11 XXXXXX12 1"
+                },
+                "reportSeverity": {
+                  "value": "TRACE",
+                  "type": "SEVERITY"
+                },
+                "xnodeCode": {
+                  "value": "XXXXXX12"
+                }
+              }
+            },
+            {
+              "messageKey": "danglingLineCreation",
+              "values": {
+                "ucteLine": {
+                  "value": "FFFFFF13 XXXXXX13 1"
+                },
+                "reportSeverity": {
+                  "value": "TRACE",
+                  "type": "SEVERITY"
+                },
+                "xnodeCode": {
+                  "value": "XXXXXX13"
+                }
+              }
+            },
+            {
+              "messageKey": "danglingLineCreation",
+              "values": {
+                "ucteLine": {
+                  "value": "FFFFFF13 XXXXXX14 1"
+                },
+                "reportSeverity": {
+                  "value": "TRACE",
+                  "type": "SEVERITY"
+                },
+                "xnodeCode": {
+                  "value": "XXXXXX14"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "messageKey": "novalueReport",
+          "values": {
+            "reportSeverity": {
+              "value": "INFO",
+              "type": "SEVERITY"
+            }
+          }
+        },
+        {
+          "messageKey": "createTransformers",
+          "values": {
+            "reportSeverity": {
+              "value": "TRACE",
+              "type": "SEVERITY"
+            }
+          }
+        }
+      ],
+      "dictionaries": {
+        "default": {
+          "UcteReading": "Reading UCTE network file",
+          "createBus": "Create bus ${bus}",
+          "createBuses": "Create buses",
+          "createBusesSubstation": "Create buses for substation ${substation}",
+          "createLines": "Create lines",
+          "createSubstation": "Create substation ${substationName}",
+          "createTransformers": "Create transformers",
+          "createVoltageLevel": "Create voltage level ${voltageLevelName}",
+          "danglingLineCreation": "Create dangling line '${ucteLine}' (Xnode='${xnodeCode}')",
+          "fixUcteLines": "Fix UCTE lines",
+          "fixUcteNodes": "Fix UCTE nodes",
+          "fixUcteRegulations": "Fix UCTE regulations",
+          "fixUcteTransformer": "Fix UCTE transformers",
+          "negativeLineResistance": "${lineId} - Real line resistance cannot be negative (${resistance} ohm)",
+          "novalueReport": "No value report",
+          "roundTripReporterJsonTest": "Test importing UCTE file frVoltageRegulatingXnode.uct"
+        }
+      }
     }
+  }
 ]

--- a/src/test/resources/expectedStructureAndElementsReportOne.json
+++ b/src/test/resources/expectedStructureAndElementsReportOne.json
@@ -7,6 +7,10 @@
         "severityList": {
           "value": "[INFO, TRACE]",
           "type": "SEVERITY"
+        },
+        "id": {
+          "value": "b4b9829e-f004-4632-ac84-4a18fd18a460",
+          "type": "ID"
         }
       },
       "children": [
@@ -16,6 +20,9 @@
             "severityList": {
               "value": "[]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "dff542a7-f6ce-489b-b57f-87bde3c7f810"
             }
           },
           "children": [
@@ -25,6 +32,9 @@
                 "severityList": {
                   "value": "[ERROR]",
                   "type": "SEVERITY"
+                },
+                "id": {
+                  "value": "47921c4c-e8a3-4bb1-9200-865fc9272b38"
                 }
               },
               "children": [
@@ -95,13 +105,28 @@
               ]
             },
             {
-              "messageKey": "fixUcteNodes"
+              "messageKey": "fixUcteNodes",
+              "values": {
+                "id": {
+                  "value": "0b6297da-6f24-45fb-b591-a0e3e071e3e0"
+                }
+              }
             },
             {
-              "messageKey": "fixUcteTransformer"
+              "messageKey": "fixUcteTransformer",
+              "values": {
+                "id": {
+                  "value": "7dc6307a-3954-496a-a16b-7ddb57a9c8a6"
+                }
+              }
             },
             {
-              "messageKey": "fixUcteRegulations"
+              "messageKey": "fixUcteRegulations",
+              "values": {
+                "id": {
+                  "value": "f3268d48-4345-43f3-9bdc-d633ad8bcb77"
+                }
+              }
             }
           ]
         },
@@ -111,6 +136,9 @@
             "severityList": {
               "value": "[]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "42056d2c-d056-47a4-8375-45fb302d5698"
             }
           },
           "children": [
@@ -123,6 +151,9 @@
                 "severityList": {
                   "value": "[TRACE]",
                   "type": "SEVERITY"
+                },
+                "id": {
+                  "value": "816a0019-3d41-48bf-9b40-414733380c45"
                 }
               },
               "children": [
@@ -186,6 +217,9 @@
             "severityList": {
               "value": "[TRACE]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "295b5fee-d9cb-4a6a-904e-e58fdba1dbd4"
             }
           },
           "children": [
@@ -272,6 +306,7 @@
       ],
       "dictionaries": {
         "default": {
+          "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13": "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13",
           "UcteReading": "Reading UCTE network file",
           "createBus": "Create bus ${bus}",
           "createBuses": "Create buses",

--- a/src/test/resources/expectedStructureAndElementsReportOneWithOnlyErrors.json
+++ b/src/test/resources/expectedStructureAndElementsReportOneWithOnlyErrors.json
@@ -1,0 +1,157 @@
+[
+  {
+    "version": "2.0",
+    "reportRoot": {
+      "messageKey": "roundTripReporterJsonTest",
+      "values": {
+        "severityList": {
+          "value": "[INFO, TRACE]",
+          "type": "SEVERITY"
+        }
+      },
+      "children": [
+        {
+          "messageKey": "UcteReading",
+          "values": {
+            "severityList": {
+              "value": "[]",
+              "type": "SEVERITY"
+            }
+          },
+          "children": [
+            {
+              "messageKey": "fixUcteLines",
+              "values": {
+                "severityList": {
+                  "value": "[ERROR]",
+                  "type": "SEVERITY"
+                }
+              },
+              "children": [
+                {
+                  "messageKey": "negativeLineResistance",
+                  "values": {
+                    "reportSeverity": {
+                      "value": "ERROR",
+                      "type": "SEVERITY"
+                    },
+                    "lineId": {
+                      "value": "FFFFFF11 XXXXXX11 1"
+                    },
+                    "resistance": {
+                      "value": 0,
+                      "type": "RESISTANCE"
+                    }
+                  }
+                },
+                {
+                  "messageKey": "negativeLineResistance",
+                  "values": {
+                    "reportSeverity": {
+                      "value": "ERROR",
+                      "type": "SEVERITY"
+                    },
+                    "lineId": {
+                      "value": "FFFFFF11 XXXXXX12 1"
+                    },
+                    "resistance": {
+                      "value": 0,
+                      "type": "RESISTANCE"
+                    }
+                  }
+                },
+                {
+                  "messageKey": "negativeLineResistance",
+                  "values": {
+                    "reportSeverity": {
+                      "value": "ERROR",
+                      "type": "SEVERITY"
+                    },
+                    "lineId": {
+                      "value": "FFFFFF13 XXXXXX13 1"
+                    },
+                    "resistance": {
+                      "value": 0,
+                      "type": "RESISTANCE"
+                    }
+                  }
+                },
+                {
+                  "messageKey": "negativeLineResistance",
+                  "values": {
+                    "reportSeverity": {
+                      "value": "ERROR",
+                      "type": "SEVERITY"
+                    },
+                    "lineId": {
+                      "value": "FFFFFF13 XXXXXX14 1"
+                    },
+                    "resistance": {
+                      "value": 0,
+                      "type": "RESISTANCE"
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "messageKey": "fixUcteNodes"
+            },
+            {
+              "messageKey": "fixUcteTransformer"
+            },
+            {
+              "messageKey": "fixUcteRegulations"
+            }
+          ]
+        },
+        {
+          "messageKey": "createBuses",
+          "values": {
+            "severityList": {
+              "value": "[]",
+              "type": "SEVERITY"
+            }
+          },
+          "children": [
+            {
+              "messageKey": "createBusesSubstation",
+              "values": {
+                "substation": {
+                  "value": "FFFFFF"
+                },
+                "severityList": {
+                  "value": "[TRACE]",
+                  "type": "SEVERITY"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "messageKey": "createLines",
+          "values": {
+            "severityList": {
+              "value": "[TRACE]",
+              "type": "SEVERITY"
+            }
+          }
+        }
+      ],
+      "dictionaries": {
+        "default": {
+          "UcteReading": "Reading UCTE network file",
+          "createBuses": "Create buses",
+          "createBusesSubstation": "Create buses for substation ${substation}",
+          "createLines": "Create lines",
+          "fixUcteLines": "Fix UCTE lines",
+          "fixUcteNodes": "Fix UCTE nodes",
+          "fixUcteRegulations": "Fix UCTE regulations",
+          "fixUcteTransformer": "Fix UCTE transformers",
+          "negativeLineResistance": "${lineId} - Real line resistance cannot be negative (${resistance} ohm)",
+          "roundTripReporterJsonTest": "Test importing UCTE file frVoltageRegulatingXnode.uct"
+        }
+      }
+    }
+  }
+]

--- a/src/test/resources/expectedStructureAndElementsReportOneWithOnlyErrors.json
+++ b/src/test/resources/expectedStructureAndElementsReportOneWithOnlyErrors.json
@@ -7,6 +7,10 @@
         "severityList": {
           "value": "[INFO, TRACE]",
           "type": "SEVERITY"
+        },
+        "id": {
+          "value": "3a165bbd-c845-4742-8915-49ded235bd05",
+          "type": "ID"
         }
       },
       "children": [
@@ -16,6 +20,9 @@
             "severityList": {
               "value": "[]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "658d5510-d1b8-48ae-8f86-b87228ce7668"
             }
           },
           "children": [
@@ -25,6 +32,9 @@
                 "severityList": {
                   "value": "[ERROR]",
                   "type": "SEVERITY"
+                },
+                "id": {
+                  "value": "1ec670d8-f026-43bf-8f6f-2b3dcee5ac8c"
                 }
               },
               "children": [
@@ -95,13 +105,28 @@
               ]
             },
             {
-              "messageKey": "fixUcteNodes"
+              "messageKey": "fixUcteNodes",
+              "values": {
+                "id": {
+                  "value": "82c9b067-321c-4beb-a0bb-0a226a716831"
+                }
+              }
             },
             {
-              "messageKey": "fixUcteTransformer"
+              "messageKey": "fixUcteTransformer",
+              "values": {
+                "id": {
+                  "value": "268efec9-d536-42b0-86ba-a17045d1615b"
+                }
+              }
             },
             {
-              "messageKey": "fixUcteRegulations"
+              "messageKey": "fixUcteRegulations",
+              "values": {
+                "id": {
+                  "value": "6a3abde5-75c1-46e0-9444-a9f6ed408439"
+                }
+              }
             }
           ]
         },
@@ -111,6 +136,9 @@
             "severityList": {
               "value": "[]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "47ea1569-6365-4c39-ad4d-62f2c92d2ce8"
             }
           },
           "children": [
@@ -123,6 +151,9 @@
                 "severityList": {
                   "value": "[TRACE]",
                   "type": "SEVERITY"
+                },
+                "id": {
+                  "value": "614f7652-4b1b-45c9-b556-3b161632462d"
                 }
               }
             }
@@ -134,12 +165,16 @@
             "severityList": {
               "value": "[TRACE]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "530cdb90-8add-4681-bd7a-d62f50ca2800"
             }
           }
         }
       ],
       "dictionaries": {
         "default": {
+          "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13": "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13",
           "UcteReading": "Reading UCTE network file",
           "createBuses": "Create buses",
           "createBusesSubstation": "Create buses for substation ${substation}",

--- a/src/test/resources/expectedStructureAndElementsReportOneWithOnlyInfos.json
+++ b/src/test/resources/expectedStructureAndElementsReportOneWithOnlyInfos.json
@@ -7,6 +7,10 @@
         "severityList": {
           "value": "[INFO, TRACE]",
           "type": "SEVERITY"
+        },
+        "id": {
+          "value": "ed562a2a-11a6-4eaf-ab81-4d67b02625f2",
+          "type": "ID"
         }
       },
       "children": [
@@ -16,6 +20,9 @@
             "severityList": {
               "value": "[]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "2abe3075-fdc7-471a-9e0f-d66836eb55a6"
             }
           },
           "children": [
@@ -25,17 +32,35 @@
                 "severityList": {
                   "value": "[ERROR]",
                   "type": "SEVERITY"
+                },
+                "id": {
+                  "value": "934ec990-a56e-437b-8ac1-cc74099b3e8e"
                 }
               }
             },
             {
-              "messageKey": "fixUcteNodes"
+              "messageKey": "fixUcteNodes",
+              "values": {
+                "id": {
+                  "value": "7c5b8153-329f-43ef-b46b-78cc74131cd7"
+                }
+              }
             },
             {
-              "messageKey": "fixUcteTransformer"
+              "messageKey": "fixUcteTransformer",
+              "values": {
+                "id": {
+                  "value": "7bc239e8-9b25-4cd6-8f6f-3918107a1519"
+                }
+              }
             },
             {
-              "messageKey": "fixUcteRegulations"
+              "messageKey": "fixUcteRegulations",
+              "values": {
+                "id": {
+                  "value": "888f19d4-db62-4e6f-b476-1b6c703e2b00"
+                }
+              }
             }
           ]
         },
@@ -45,6 +70,9 @@
             "severityList": {
               "value": "[]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "6d4ba099-ff52-4cbc-ace9-bb685c9a9374"
             }
           },
           "children": [
@@ -57,6 +85,9 @@
                 "severityList": {
                   "value": "[TRACE]",
                   "type": "SEVERITY"
+                },
+                "id": {
+                  "value": "4fd914fa-4b40-497e-afa3-e11246dc7914"
                 }
               }
             }
@@ -68,6 +99,9 @@
             "severityList": {
               "value": "[TRACE]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "1d6a5592-9b40-4025-a957-4ea79de37614"
             }
           }
         },
@@ -83,6 +117,7 @@
       ],
       "dictionaries": {
         "default": {
+          "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13": "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13",
           "UcteReading": "Reading UCTE network file",
           "createBuses": "Create buses",
           "createBusesSubstation": "Create buses for substation ${substation}",

--- a/src/test/resources/expectedStructureAndElementsReportOneWithOnlyInfos.json
+++ b/src/test/resources/expectedStructureAndElementsReportOneWithOnlyInfos.json
@@ -1,0 +1,100 @@
+[
+  {
+    "version": "2.0",
+    "reportRoot": {
+      "messageKey": "roundTripReporterJsonTest",
+      "values": {
+        "severityList": {
+          "value": "[INFO, TRACE]",
+          "type": "SEVERITY"
+        }
+      },
+      "children": [
+        {
+          "messageKey": "UcteReading",
+          "values": {
+            "severityList": {
+              "value": "[]",
+              "type": "SEVERITY"
+            }
+          },
+          "children": [
+            {
+              "messageKey": "fixUcteLines",
+              "values": {
+                "severityList": {
+                  "value": "[ERROR]",
+                  "type": "SEVERITY"
+                }
+              }
+            },
+            {
+              "messageKey": "fixUcteNodes"
+            },
+            {
+              "messageKey": "fixUcteTransformer"
+            },
+            {
+              "messageKey": "fixUcteRegulations"
+            }
+          ]
+        },
+        {
+          "messageKey": "createBuses",
+          "values": {
+            "severityList": {
+              "value": "[]",
+              "type": "SEVERITY"
+            }
+          },
+          "children": [
+            {
+              "messageKey": "createBusesSubstation",
+              "values": {
+                "substation": {
+                  "value": "FFFFFF"
+                },
+                "severityList": {
+                  "value": "[TRACE]",
+                  "type": "SEVERITY"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "messageKey": "createLines",
+          "values": {
+            "severityList": {
+              "value": "[TRACE]",
+              "type": "SEVERITY"
+            }
+          }
+        },
+        {
+          "messageKey": "novalueReport",
+          "values": {
+            "reportSeverity": {
+              "value": "INFO",
+              "type": "SEVERITY"
+            }
+          }
+        }
+      ],
+      "dictionaries": {
+        "default": {
+          "UcteReading": "Reading UCTE network file",
+          "createBuses": "Create buses",
+          "createBusesSubstation": "Create buses for substation ${substation}",
+          "createLines": "Create lines",
+          "fixUcteLines": "Fix UCTE lines",
+          "fixUcteNodes": "Fix UCTE nodes",
+          "fixUcteRegulations": "Fix UCTE regulations",
+          "fixUcteTransformer": "Fix UCTE transformers",
+          "novalueReport": "No value report",
+          "roundTripReporterJsonTest": "Test importing UCTE file frVoltageRegulatingXnode.uct"
+        }
+      }
+    }
+  }
+]

--- a/src/test/resources/expectedStructureAndNoElementReportOne.json
+++ b/src/test/resources/expectedStructureAndNoElementReportOne.json
@@ -7,6 +7,10 @@
         "severityList": {
           "value": "[INFO, TRACE]",
           "type": "SEVERITY"
+        },
+        "id": {
+          "value": "bacffc28-3a79-4dea-a260-a9eaf1888c95",
+          "type": "ID"
         }
       },
       "children": [
@@ -16,6 +20,9 @@
             "severityList": {
               "value": "[]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "1e3c954f-ec11-4a0c-8631-18b75b2b8b54"
             }
           },
           "children": [
@@ -25,17 +32,35 @@
                 "severityList": {
                   "value": "[ERROR]",
                   "type": "SEVERITY"
+                },
+                "id": {
+                  "value": "22b6d7b3-74a5-4a95-999c-289700b98665"
                 }
               }
             },
             {
-              "messageKey": "fixUcteNodes"
+              "messageKey": "fixUcteNodes",
+              "values": {
+                "id": {
+                  "value": "2a945bb4-2ac7-4f02-9996-020c32007ad4"
+                }
+              }
             },
             {
-              "messageKey": "fixUcteTransformer"
+              "messageKey": "fixUcteTransformer",
+              "values": {
+                "id": {
+                  "value": "accfc943-8b7a-4d27-ab2c-d751af954bde"
+                }
+              }
             },
             {
-              "messageKey": "fixUcteRegulations"
+              "messageKey": "fixUcteRegulations",
+              "values": {
+                "id": {
+                  "value": "fa07cdb6-90cc-400e-8a17-1a276644b6f4"
+                }
+              }
             }
           ]
         },
@@ -45,6 +70,9 @@
             "severityList": {
               "value": "[]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "577662d7-161b-4372-a5f7-2bb8b80f0e6b"
             }
           },
           "children": [
@@ -57,6 +85,9 @@
                 "severityList": {
                   "value": "[TRACE]",
                   "type": "SEVERITY"
+                },
+                "id": {
+                  "value": "3f93df06-6268-47c5-b571-8726de0b33bd"
                 }
               }
             }
@@ -68,12 +99,16 @@
             "severityList": {
               "value": "[TRACE]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "6b0fb43b-2068-47d8-9b14-2a73160adab4"
             }
           }
         }
       ],
       "dictionaries": {
         "default": {
+          "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13": "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13",
           "UcteReading": "Reading UCTE network file",
           "createBuses": "Create buses",
           "createBusesSubstation": "Create buses for substation ${substation}",

--- a/src/test/resources/expectedStructureAndNoElementReportOne.json
+++ b/src/test/resources/expectedStructureAndNoElementReportOne.json
@@ -1,79 +1,90 @@
 [
-    {
-        "version": "2.0",
-        "reportRoot": {
-            "messageKey": "roundTripReporterJsonTest",
-            "values": {
-                "severityList": {
-                    "value": "[INFO, TRACE]",
-                    "type": "SEVERITY"
-                }
-            },
-            "children": [
-                {
-                    "messageKey": "UcteReading",
-                    "values": {
-                        "severityList": {
-                            "value": "[UNKNOWN]",
-                            "type": "SEVERITY"
-                        }
-                    },
-                    "children": [
-                        {
-                            "messageKey": "fixUcteLines",
-                            "values": {
-                                "severityList": {
-                                    "value": "[ERROR]",
-                                    "type": "SEVERITY"
-                                }
-                            }
-                        }
-                    ]
-                },
-                {
-                    "messageKey": "createBuses",
-                    "values": {
-                        "severityList": {
-                            "value": "[]",
-                            "type": "SEVERITY"
-                        }
-                    },
-                    "children": [
-                        {
-                            "messageKey": "createBusesSubstation",
-                            "values": {
-                                "substation": {
-                                    "value": "FFFFFF"
-                                },
-                                "severityList": {
-                                    "value": "[TRACE]",
-                                    "type": "SEVERITY"
-                                }
-                            }
-                        }
-                    ]
-                },
-                {
-                    "messageKey": "createLines",
-                    "values": {
-                        "severityList": {
-                            "value": "[TRACE]",
-                            "type": "SEVERITY"
-                        }
-                    }
-                }
-            ],
-            "dictionaries": {
-                "default": {
-                    "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13": "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13",
-                    "UcteReading": "Reading UCTE network file",
-                    "createBuses": "Create buses",
-                    "createBusesSubstation": "Create buses for substation ${substation}",
-                    "createLines": "Create lines",
-                    "fixUcteLines": "Fix UCTE lines",
-                    "roundTripReporterJsonTest": "Test importing UCTE file frVoltageRegulatingXnode.uct"
-                }
-            }
+  {
+    "version": "2.0",
+    "reportRoot": {
+      "messageKey": "roundTripReporterJsonTest",
+      "values": {
+        "severityList": {
+          "value": "[INFO, TRACE]",
+          "type": "SEVERITY"
         }
+      },
+      "children": [
+        {
+          "messageKey": "UcteReading",
+          "values": {
+            "severityList": {
+              "value": "[]",
+              "type": "SEVERITY"
+            }
+          },
+          "children": [
+            {
+              "messageKey": "fixUcteLines",
+              "values": {
+                "severityList": {
+                  "value": "[ERROR]",
+                  "type": "SEVERITY"
+                }
+              }
+            },
+            {
+              "messageKey": "fixUcteNodes"
+            },
+            {
+              "messageKey": "fixUcteTransformer"
+            },
+            {
+              "messageKey": "fixUcteRegulations"
+            }
+          ]
+        },
+        {
+          "messageKey": "createBuses",
+          "values": {
+            "severityList": {
+              "value": "[]",
+              "type": "SEVERITY"
+            }
+          },
+          "children": [
+            {
+              "messageKey": "createBusesSubstation",
+              "values": {
+                "substation": {
+                  "value": "FFFFFF"
+                },
+                "severityList": {
+                  "value": "[TRACE]",
+                  "type": "SEVERITY"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "messageKey": "createLines",
+          "values": {
+            "severityList": {
+              "value": "[TRACE]",
+              "type": "SEVERITY"
+            }
+          }
+        }
+      ],
+      "dictionaries": {
+        "default": {
+          "UcteReading": "Reading UCTE network file",
+          "createBuses": "Create buses",
+          "createBusesSubstation": "Create buses for substation ${substation}",
+          "createLines": "Create lines",
+          "fixUcteLines": "Fix UCTE lines",
+          "fixUcteNodes": "Fix UCTE nodes",
+          "fixUcteRegulations": "Fix UCTE regulations",
+          "fixUcteTransformer": "Fix UCTE transformers",
+          "roundTripReporterJsonTest": "Test importing UCTE file frVoltageRegulatingXnode.uct"
+        }
+      }
     }
+  }
 ]

--- a/src/test/resources/expectedStructureOnlyReportOne.json
+++ b/src/test/resources/expectedStructureOnlyReportOne.json
@@ -9,7 +9,7 @@
           "type": "SEVERITY"
         },
         "id": {
-          "value": "5edfa318-2c4d-4682-a67c-3aed7c13686c",
+          "value": "c6893511-9d40-427b-8a8a-9a3dcf84ebe0",
           "type": "ID"
         }
       },
@@ -22,7 +22,7 @@
               "type": "SEVERITY"
             },
             "id": {
-              "value": "b76b6bfb-1dc7-492b-9917-44e6af85053c"
+              "value": "9b57831b-f9b2-466e-a223-f896f843bda2"
             }
           },
           "children": [
@@ -34,7 +34,31 @@
                   "type": "SEVERITY"
                 },
                 "id": {
-                  "value": "31a9fb49-9e1d-418e-9200-352b9ab1d97a"
+                  "value": "43af593f-e6fb-44c8-b5ee-ffaab0d8c0d9"
+                }
+              }
+            },
+            {
+              "messageKey": "fixUcteNodes",
+              "values": {
+                "id": {
+                  "value": "b4cdcf7c-fff1-48c8-913a-2e777b9c3fd2"
+                }
+              }
+            },
+            {
+              "messageKey": "fixUcteTransformer",
+              "values": {
+                "id": {
+                  "value": "6f12aba4-8a2a-449a-93fc-7db9951418e2"
+                }
+              }
+            },
+            {
+              "messageKey": "fixUcteRegulations",
+              "values": {
+                "id": {
+                  "value": "1def4303-aaa9-488d-951e-38f8495bd8b2"
                 }
               }
             }
@@ -48,7 +72,7 @@
               "type": "SEVERITY"
             },
             "id": {
-              "value": "472a23ec-ebff-4a22-9eb6-bc7826c5f8f4"
+              "value": "ed425133-b70c-465c-b311-deb3b07073d9"
             }
           },
           "children": [
@@ -63,7 +87,7 @@
                   "type": "SEVERITY"
                 },
                 "id": {
-                  "value": "93fad821-006b-4c72-a80e-90430b70558d"
+                  "value": "2e0094f2-410e-4186-ad04-795d7c3a08b6"
                 }
               }
             }
@@ -77,7 +101,7 @@
               "type": "SEVERITY"
             },
             "id": {
-              "value": "0472d16f-2111-42dc-948b-66e0fa76c503"
+              "value": "0a7dc6e2-5712-42af-a053-b4b7352a4682"
             }
           }
         }
@@ -90,6 +114,9 @@
           "createBusesSubstation": "Create buses for substation ${substation}",
           "createLines": "Create lines",
           "fixUcteLines": "Fix UCTE lines",
+          "fixUcteNodes": "Fix UCTE nodes",
+          "fixUcteRegulations": "Fix UCTE regulations",
+          "fixUcteTransformer": "Fix UCTE transformers",
           "roundTripReporterJsonTest": "Test importing UCTE file frVoltageRegulatingXnode.uct"
         }
       }

--- a/src/test/resources/expectedStructureOnlyReportOne.json
+++ b/src/test/resources/expectedStructureOnlyReportOne.json
@@ -1,44 +1,98 @@
 [
-    {
-        "version": "2.0",
-        "reportRoot": {
-            "messageKey": "roundTripReporterJsonTest",
-            "children": [
-                {
-                    "messageKey": "UcteReading",
-                    "children": [
-                        {
-                            "messageKey": "fixUcteLines"
-                        }
-                    ]
-                },
-                {
-                    "messageKey": "createBuses",
-                    "children": [
-                        {
-                            "messageKey": "createBusesSubstation",
-                            "values": {
-                                "substation": {
-                                    "value": "FFFFFF"
-                                }
-                            }
-                        }
-                    ]
-                },
-                {
-                    "messageKey": "createLines"
-                }
-            ],
-            "dictionaries": {
-                "default": {
-                    "UcteReading": "Reading UCTE network file",
-                    "createLines": "Create lines",
-                    "roundTripReporterJsonTest": "Test importing UCTE file frVoltageRegulatingXnode.uct",
-                    "createBusesSubstation": "Create buses for substation ${substation}",
-                    "createBuses": "Create buses",
-                    "fixUcteLines": "Fix UCTE lines"
-                }
-            }
+  {
+    "version": "2.0",
+    "reportRoot": {
+      "messageKey": "roundTripReporterJsonTest",
+      "values": {
+        "severityList": {
+          "value": "[INFO, TRACE]",
+          "type": "SEVERITY"
+        },
+        "id": {
+          "value": "5edfa318-2c4d-4682-a67c-3aed7c13686c",
+          "type": "ID"
         }
+      },
+      "children": [
+        {
+          "messageKey": "UcteReading",
+          "values": {
+            "severityList": {
+              "value": "[]",
+              "type": "SEVERITY"
+            },
+            "id": {
+              "value": "b76b6bfb-1dc7-492b-9917-44e6af85053c"
+            }
+          },
+          "children": [
+            {
+              "messageKey": "fixUcteLines",
+              "values": {
+                "severityList": {
+                  "value": "[ERROR]",
+                  "type": "SEVERITY"
+                },
+                "id": {
+                  "value": "31a9fb49-9e1d-418e-9200-352b9ab1d97a"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "messageKey": "createBuses",
+          "values": {
+            "severityList": {
+              "value": "[]",
+              "type": "SEVERITY"
+            },
+            "id": {
+              "value": "472a23ec-ebff-4a22-9eb6-bc7826c5f8f4"
+            }
+          },
+          "children": [
+            {
+              "messageKey": "createBusesSubstation",
+              "values": {
+                "substation": {
+                  "value": "FFFFFF"
+                },
+                "severityList": {
+                  "value": "[TRACE]",
+                  "type": "SEVERITY"
+                },
+                "id": {
+                  "value": "93fad821-006b-4c72-a80e-90430b70558d"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "messageKey": "createLines",
+          "values": {
+            "severityList": {
+              "value": "[TRACE]",
+              "type": "SEVERITY"
+            },
+            "id": {
+              "value": "0472d16f-2111-42dc-948b-66e0fa76c503"
+            }
+          }
+        }
+      ],
+      "dictionaries": {
+        "default": {
+          "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13": "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13",
+          "UcteReading": "Reading UCTE network file",
+          "createBuses": "Create buses",
+          "createBusesSubstation": "Create buses for substation ${substation}",
+          "createLines": "Create lines",
+          "fixUcteLines": "Fix UCTE lines",
+          "roundTripReporterJsonTest": "Test importing UCTE file frVoltageRegulatingXnode.uct"
+        }
+      }
     }
+  }
 ]

--- a/src/test/resources/reportConcat.json
+++ b/src/test/resources/reportConcat.json
@@ -7,6 +7,10 @@
         "severityList": {
           "value": "[INFO, TRACE]",
           "type": "SEVERITY"
+        },
+        "id": {
+          "value": "2935b092-9d13-40b3-b8fb-f892956fc351",
+          "type": "ID"
         }
       },
       "children": [
@@ -16,6 +20,9 @@
             "severityList": {
               "value": "[]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "658fc8ae-b4fa-406f-b22d-9d0b49d4531e"
             }
           },
           "children": [
@@ -25,6 +32,9 @@
                 "severityList": {
                   "value": "[ERROR]",
                   "type": "SEVERITY"
+                },
+                "id": {
+                  "value": "db106c74-28bd-4f29-b2cd-e63dd2f4b869"
                 }
               },
               "children": [
@@ -95,13 +105,28 @@
               ]
             },
             {
-              "messageKey": "fixUcteNodes"
+              "messageKey": "fixUcteNodes",
+              "values": {
+                "id": {
+                  "value": "96c5aa57-051c-4668-9105-4e19da25f86a"
+                }
+              }
             },
             {
-              "messageKey": "fixUcteTransformer"
+              "messageKey": "fixUcteTransformer",
+              "values": {
+                "id": {
+                  "value": "850b7462-c33c-4e76-9f57-73267cefddf8"
+                }
+              }
             },
             {
-              "messageKey": "fixUcteRegulations"
+              "messageKey": "fixUcteRegulations",
+              "values": {
+                "id": {
+                  "value": "4bffc681-d078-4b39-bd45-138857fe7ef1"
+                }
+              }
             }
           ]
         },
@@ -111,6 +136,9 @@
             "severityList": {
               "value": "[]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "2b30c2a7-ac51-4a24-aace-43b13db8e625"
             }
           },
           "children": [
@@ -123,6 +151,9 @@
                 "severityList": {
                   "value": "[TRACE]",
                   "type": "SEVERITY"
+                },
+                "id": {
+                  "value": "f63caa8f-31b8-47b6-87a8-bc9b9c803c63"
                 }
               },
               "children": [
@@ -186,6 +217,9 @@
             "severityList": {
               "value": "[TRACE]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "e02c165c-0b9c-436d-aa09-1313abef0821"
             }
           },
           "children": [
@@ -272,6 +306,7 @@
       ],
       "dictionaries": {
         "default": {
+          "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13": "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13",
           "UcteReading": "Reading UCTE network file",
           "createBus": "Create bus ${bus}",
           "createBuses": "Create buses",
@@ -302,6 +337,10 @@
         "severityList": {
           "value": "[INFO]",
           "type": "SEVERITY"
+        },
+        "id": {
+          "value": "4c29c759-e838-485d-91b9-529491082466",
+          "type": "ID"
         }
       },
       "children": [
@@ -311,11 +350,19 @@
             "severityList": {
               "value": "[]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "16273bc4-bdd9-4ad4-b579-d7740b93efc5"
             }
           },
           "children": [
             {
-              "messageKey": "fixUcteNodes"
+              "messageKey": "fixUcteNodes",
+              "values": {
+                "id": {
+                  "value": "86c32a55-cc30-46b5-8cc6-b075ac6d09ad"
+                }
+              }
             }
           ]
         },
@@ -331,6 +378,7 @@
       ],
       "dictionaries": {
         "default": {
+          "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13": "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13",
           "UcteReading": "Reading UCTE network file",
           "createBus": "Create bus ${bus}",
           "createBuses": "Create buses",

--- a/src/test/resources/reportConcat.json
+++ b/src/test/resources/reportConcat.json
@@ -3,21 +3,30 @@
     "version": "2.0",
     "reportRoot": {
       "messageKey": "roundTripReporterJsonTest",
+      "values": {
+        "severityList": {
+          "value": "[INFO, TRACE]",
+          "type": "SEVERITY"
+        }
+      },
       "children": [
         {
-          "messageKey": "novalueReport",
+          "messageKey": "UcteReading",
           "values": {
-            "reportSeverity": {
-              "value": "INFO",
+            "severityList": {
+              "value": "[]",
               "type": "SEVERITY"
             }
-          }
-        },
-        {
-          "messageKey": "UcteReading",
+          },
           "children": [
             {
               "messageKey": "fixUcteLines",
+              "values": {
+                "severityList": {
+                  "value": "[ERROR]",
+                  "type": "SEVERITY"
+                }
+              },
               "children": [
                 {
                   "messageKey": "negativeLineResistance",
@@ -46,7 +55,7 @@
                       "value": "FFFFFF11 XXXXXX12 1"
                     },
                     "resistance": {
-                      "value": 0.0,
+                      "value": 0,
                       "type": "RESISTANCE"
                     }
                   }
@@ -62,7 +71,7 @@
                       "value": "FFFFFF13 XXXXXX13 1"
                     },
                     "resistance": {
-                      "value": 0.0,
+                      "value": 0,
                       "type": "RESISTANCE"
                     }
                   }
@@ -78,23 +87,42 @@
                       "value": "FFFFFF13 XXXXXX14 1"
                     },
                     "resistance": {
-                      "value": 0.0,
+                      "value": 0,
                       "type": "RESISTANCE"
                     }
                   }
                 }
               ]
+            },
+            {
+              "messageKey": "fixUcteNodes"
+            },
+            {
+              "messageKey": "fixUcteTransformer"
+            },
+            {
+              "messageKey": "fixUcteRegulations"
             }
           ]
         },
         {
           "messageKey": "createBuses",
+          "values": {
+            "severityList": {
+              "value": "[]",
+              "type": "SEVERITY"
+            }
+          },
           "children": [
             {
               "messageKey": "createBusesSubstation",
               "values": {
                 "substation": {
                   "value": "FFFFFF"
+                },
+                "severityList": {
+                  "value": "[TRACE]",
+                  "type": "SEVERITY"
                 }
               },
               "children": [
@@ -154,6 +182,12 @@
         },
         {
           "messageKey": "createLines",
+          "values": {
+            "severityList": {
+              "value": "[TRACE]",
+              "type": "SEVERITY"
+            }
+          },
           "children": [
             {
               "messageKey": "danglingLineCreation",
@@ -218,6 +252,15 @@
           ]
         },
         {
+          "messageKey": "novalueReport",
+          "values": {
+            "reportSeverity": {
+              "value": "INFO",
+              "type": "SEVERITY"
+            }
+          }
+        },
+        {
           "messageKey": "createTransformers",
           "values": {
             "reportSeverity": {
@@ -239,6 +282,9 @@
           "createVoltageLevel": "Create voltage level ${voltageLevelName}",
           "danglingLineCreation": "Create dangling line '${ucteLine}' (Xnode='${xnodeCode}')",
           "fixUcteLines": "Fix UCTE lines",
+          "fixUcteNodes": "(missing message key in dictionary)",
+          "fixUcteRegulations": "Fix UCTE regulations",
+          "fixUcteTransformer": "Fix UCTE transformers",
           "negativeLineResistance": "${lineId} - Real line resistance cannot be negative (${resistance} ohm)",
           "novalueReport": "(missing message key in dictionary)",
           "roundTripReporterJsonTest": "Test importing UCTE file frVoltageRegulatingXnode.uct",
@@ -252,7 +298,27 @@
     "version": "2.0",
     "reportRoot": {
       "messageKey": "testImport",
+      "values": {
+        "severityList": {
+          "value": "[INFO]",
+          "type": "SEVERITY"
+        }
+      },
       "children": [
+        {
+          "messageKey": "testNewValue",
+          "values": {
+            "severityList": {
+              "value": "[]",
+              "type": "SEVERITY"
+            }
+          },
+          "children": [
+            {
+              "messageKey": "fixUcteNodes"
+            }
+          ]
+        },
         {
           "messageKey": "novalueReport",
           "values": {
@@ -261,9 +327,6 @@
               "type": "SEVERITY"
             }
           }
-        },
-        {
-          "messageKey": "testNewValue"
         }
       ],
       "dictionaries": {
@@ -278,6 +341,9 @@
           "createVoltageLevel": "Create voltage level ${voltageLevelName}",
           "danglingLineCreation": "Create dangling line '${ucteLine}' (Xnode='${xnodeCode}')",
           "fixUcteLines": "Fix UCTE lines",
+          "fixUcteNodes": "(missing message key in dictionary)",
+          "fixUcteRegulations": "Fix UCTE regulations",
+          "fixUcteTransformer": "Fix UCTE transformers",
           "negativeLineResistance": "${lineId} - Real line resistance cannot be negative (${resistance} ohm)",
           "novalueReport": "(missing message key in dictionary)",
           "roundTripReporterJsonTest": "Test importing UCTE file frVoltageRegulatingXnode.uct",

--- a/src/test/resources/reportConcat2.json
+++ b/src/test/resources/reportConcat2.json
@@ -3,12 +3,30 @@
     "version": "2.0",
     "reportRoot": {
       "messageKey": "roundTripReporterJsonTest",
+      "values": {
+        "severityList": {
+          "value": "[INFO, TRACE]",
+          "type": "SEVERITY"
+        }
+      },
       "children": [
         {
           "messageKey": "UcteReading",
+          "values": {
+            "severityList": {
+              "value": "[]",
+              "type": "SEVERITY"
+            }
+          },
           "children": [
             {
               "messageKey": "fixUcteLines",
+              "values": {
+                "severityList": {
+                  "value": "[ERROR]",
+                  "type": "SEVERITY"
+                }
+              },
               "children": [
                 {
                   "messageKey": "negativeLineResistance",
@@ -37,7 +55,7 @@
                       "value": "FFFFFF11 XXXXXX12 1"
                     },
                     "resistance": {
-                      "value": 0.0,
+                      "value": 0,
                       "type": "RESISTANCE"
                     }
                   }
@@ -53,7 +71,7 @@
                       "value": "FFFFFF13 XXXXXX13 1"
                     },
                     "resistance": {
-                      "value": 0.0,
+                      "value": 0,
                       "type": "RESISTANCE"
                     }
                   }
@@ -69,23 +87,42 @@
                       "value": "FFFFFF13 XXXXXX14 1"
                     },
                     "resistance": {
-                      "value": 0.0,
+                      "value": 0,
                       "type": "RESISTANCE"
                     }
                   }
                 }
               ]
+            },
+            {
+              "messageKey": "fixUcteNodes"
+            },
+            {
+              "messageKey": "fixUcteTransformer"
+            },
+            {
+              "messageKey": "fixUcteRegulations"
             }
           ]
         },
         {
           "messageKey": "createBuses",
+          "values": {
+            "severityList": {
+              "value": "[]",
+              "type": "SEVERITY"
+            }
+          },
           "children": [
             {
               "messageKey": "createBusesSubstation",
               "values": {
                 "substation": {
                   "value": "FFFFFF"
+                },
+                "severityList": {
+                  "value": "[TRACE]",
+                  "type": "SEVERITY"
                 }
               },
               "children": [
@@ -145,6 +182,12 @@
         },
         {
           "messageKey": "createLines",
+          "values": {
+            "severityList": {
+              "value": "[TRACE]",
+              "type": "SEVERITY"
+            }
+          },
           "children": [
             {
               "messageKey": "danglingLineCreation",
@@ -239,6 +282,9 @@
           "createVoltageLevel": "Create voltage level ${voltageLevelName}",
           "danglingLineCreation": "Create dangling line '${ucteLine}' (Xnode='${xnodeCode}')",
           "fixUcteLines": "Fix UCTE lines",
+          "fixUcteNodes": "Fix UCTE nodes",
+          "fixUcteRegulations": "Fix UCTE regulations",
+          "fixUcteTransformer": "Fix UCTE transformers",
           "negativeLineResistance": "${lineId} - Real line resistance cannot be negative (${resistance} ohm)",
           "novalueReport": "No value report",
           "roundTripReporterJsonTest": "Test importing UCTE file frVoltageRegulatingXnode.uct",
@@ -252,9 +298,26 @@
     "version": "2.0",
     "reportRoot": {
       "messageKey": "testImport",
+      "values": {
+        "severityList": {
+          "value": "[INFO]",
+          "type": "SEVERITY"
+        }
+      },
       "children": [
         {
-          "messageKey": "testNewValue"
+          "messageKey": "testNewValue",
+          "values": {
+            "severityList": {
+              "value": "[]",
+              "type": "SEVERITY"
+            }
+          },
+          "children": [
+            {
+              "messageKey": "fixUcteNodes"
+            }
+          ]
         },
         {
           "messageKey": "novalueReport",
@@ -278,6 +341,9 @@
           "createVoltageLevel": "Create voltage level ${voltageLevelName}",
           "danglingLineCreation": "Create dangling line '${ucteLine}' (Xnode='${xnodeCode}')",
           "fixUcteLines": "Fix UCTE lines",
+          "fixUcteNodes": "Fix UCTE nodes",
+          "fixUcteRegulations": "Fix UCTE regulations",
+          "fixUcteTransformer": "Fix UCTE transformers",
           "negativeLineResistance": "${lineId} - Real line resistance cannot be negative (${resistance} ohm)",
           "novalueReport": "No value report",
           "roundTripReporterJsonTest": "Test importing UCTE file frVoltageRegulatingXnode.uct",
@@ -291,21 +357,30 @@
     "version": "2.0",
     "reportRoot": {
       "messageKey": "roundTripReporterJsonTest",
+      "values": {
+        "severityList": {
+          "value": "[INFO, TRACE]",
+          "type": "SEVERITY"
+        }
+      },
       "children": [
         {
-          "messageKey": "novalueReport",
+          "messageKey": "UcteReading",
           "values": {
-            "reportSeverity": {
-              "value": "INFO",
+            "severityList": {
+              "value": "[]",
               "type": "SEVERITY"
             }
-          }
-        },
-        {
-          "messageKey": "UcteReading",
+          },
           "children": [
             {
               "messageKey": "fixUcteLines",
+              "values": {
+                "severityList": {
+                  "value": "[ERROR]",
+                  "type": "SEVERITY"
+                }
+              },
               "children": [
                 {
                   "messageKey": "negativeLineResistance",
@@ -334,7 +409,7 @@
                       "value": "FFFFFF11 XXXXXX12 1"
                     },
                     "resistance": {
-                      "value": 0.0,
+                      "value": 0,
                       "type": "RESISTANCE"
                     }
                   }
@@ -350,7 +425,7 @@
                       "value": "FFFFFF13 XXXXXX13 1"
                     },
                     "resistance": {
-                      "value": 0.0,
+                      "value": 0,
                       "type": "RESISTANCE"
                     }
                   }
@@ -366,23 +441,42 @@
                       "value": "FFFFFF13 XXXXXX14 1"
                     },
                     "resistance": {
-                      "value": 0.0,
+                      "value": 0,
                       "type": "RESISTANCE"
                     }
                   }
                 }
               ]
+            },
+            {
+              "messageKey": "fixUcteNodes"
+            },
+            {
+              "messageKey": "fixUcteTransformer"
+            },
+            {
+              "messageKey": "fixUcteRegulations"
             }
           ]
         },
         {
           "messageKey": "createBuses",
+          "values": {
+            "severityList": {
+              "value": "[]",
+              "type": "SEVERITY"
+            }
+          },
           "children": [
             {
               "messageKey": "createBusesSubstation",
               "values": {
                 "substation": {
                   "value": "FFFFFF"
+                },
+                "severityList": {
+                  "value": "[TRACE]",
+                  "type": "SEVERITY"
                 }
               },
               "children": [
@@ -437,10 +531,17 @@
                   }
                 }
               ]
-            }          ]
+            }
+          ]
         },
         {
           "messageKey": "createLines",
+          "values": {
+            "severityList": {
+              "value": "[TRACE]",
+              "type": "SEVERITY"
+            }
+          },
           "children": [
             {
               "messageKey": "danglingLineCreation",
@@ -505,6 +606,15 @@
           ]
         },
         {
+          "messageKey": "novalueReport",
+          "values": {
+            "reportSeverity": {
+              "value": "INFO",
+              "type": "SEVERITY"
+            }
+          }
+        },
+        {
           "messageKey": "createTransformers",
           "values": {
             "reportSeverity": {
@@ -526,6 +636,9 @@
           "createVoltageLevel": "Create voltage level ${voltageLevelName}",
           "danglingLineCreation": "Create dangling line '${ucteLine}' (Xnode='${xnodeCode}')",
           "fixUcteLines": "Fix UCTE lines",
+          "fixUcteNodes": "Fix UCTE nodes",
+          "fixUcteRegulations": "Fix UCTE regulations",
+          "fixUcteTransformer": "Fix UCTE transformers",
           "negativeLineResistance": "${lineId} - Real line resistance cannot be negative (${resistance} ohm)",
           "novalueReport": "No value report",
           "roundTripReporterJsonTest": "Test importing UCTE file frVoltageRegulatingXnode.uct",

--- a/src/test/resources/reportConcat2.json
+++ b/src/test/resources/reportConcat2.json
@@ -7,6 +7,10 @@
         "severityList": {
           "value": "[INFO, TRACE]",
           "type": "SEVERITY"
+        },
+        "id": {
+          "value": "58a4819a-a987-422e-9bb3-ef24646ad01e",
+          "type": "ID"
         }
       },
       "children": [
@@ -16,6 +20,9 @@
             "severityList": {
               "value": "[]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "29253283-8c86-4cae-9771-d7f558b156c2"
             }
           },
           "children": [
@@ -25,6 +32,9 @@
                 "severityList": {
                   "value": "[ERROR]",
                   "type": "SEVERITY"
+                },
+                "id": {
+                  "value": "38c0198a-0734-4a47-9493-d69f2201d767"
                 }
               },
               "children": [
@@ -95,13 +105,28 @@
               ]
             },
             {
-              "messageKey": "fixUcteNodes"
+              "messageKey": "fixUcteNodes",
+              "values": {
+                "id": {
+                  "value": "37d5720f-6264-497b-a530-0541487b0763"
+                }
+              }
             },
             {
-              "messageKey": "fixUcteTransformer"
+              "messageKey": "fixUcteTransformer",
+              "values": {
+                "id": {
+                  "value": "d5694b6a-4890-443e-b443-fd94d3e253c4"
+                }
+              }
             },
             {
-              "messageKey": "fixUcteRegulations"
+              "messageKey": "fixUcteRegulations",
+              "values": {
+                "id": {
+                  "value": "87dfd181-3e90-4aa0-8447-d6f8bf9508bb"
+                }
+              }
             }
           ]
         },
@@ -111,6 +136,9 @@
             "severityList": {
               "value": "[]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "076bf511-6497-4c5e-90a9-a66bad97eb98"
             }
           },
           "children": [
@@ -123,6 +151,9 @@
                 "severityList": {
                   "value": "[TRACE]",
                   "type": "SEVERITY"
+                },
+                "id": {
+                  "value": "a2e10aad-cecf-4a67-adf7-eff57952f78d"
                 }
               },
               "children": [
@@ -186,6 +217,9 @@
             "severityList": {
               "value": "[TRACE]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "e42f4e21-b9bb-42c9-83db-87a5940cceb5"
             }
           },
           "children": [
@@ -272,6 +306,7 @@
       ],
       "dictionaries": {
         "default": {
+          "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13": "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13",
           "UcteReading": "Reading UCTE network file",
           "createBus": "Create bus ${bus}",
           "createBuses": "Create buses",
@@ -302,6 +337,10 @@
         "severityList": {
           "value": "[INFO]",
           "type": "SEVERITY"
+        },
+        "id": {
+          "value": "8d957907-0e2b-46e7-9b2a-2960ee2a2f3a",
+          "type": "ID"
         }
       },
       "children": [
@@ -311,11 +350,19 @@
             "severityList": {
               "value": "[]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "e9ac003d-6924-416a-92aa-eeec9ef3138b"
             }
           },
           "children": [
             {
-              "messageKey": "fixUcteNodes"
+              "messageKey": "fixUcteNodes",
+              "values": {
+                "id": {
+                  "value": "39831972-7771-4219-92bb-21ddad0f78bd"
+                }
+              }
             }
           ]
         },
@@ -331,6 +378,7 @@
       ],
       "dictionaries": {
         "default": {
+          "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13": "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13",
           "UcteReading": "Reading UCTE network file",
           "createBus": "Create bus ${bus}",
           "createBuses": "Create buses",
@@ -361,6 +409,10 @@
         "severityList": {
           "value": "[INFO, TRACE]",
           "type": "SEVERITY"
+        },
+        "id": {
+          "value": "1690b347-c460-4ba2-aa00-4cabca538a69",
+          "type": "ID"
         }
       },
       "children": [
@@ -370,6 +422,9 @@
             "severityList": {
               "value": "[]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "dd4bb1b9-f5df-45a0-aa13-d0751763becc"
             }
           },
           "children": [
@@ -379,6 +434,9 @@
                 "severityList": {
                   "value": "[ERROR]",
                   "type": "SEVERITY"
+                },
+                "id": {
+                  "value": "895d91ee-b03c-4bba-85fa-8a8f12912075"
                 }
               },
               "children": [
@@ -449,13 +507,28 @@
               ]
             },
             {
-              "messageKey": "fixUcteNodes"
+              "messageKey": "fixUcteNodes",
+              "values": {
+                "id": {
+                  "value": "15f447ce-40a7-4703-9178-24ab50e66e51"
+                }
+              }
             },
             {
-              "messageKey": "fixUcteTransformer"
+              "messageKey": "fixUcteTransformer",
+              "values": {
+                "id": {
+                  "value": "c0cb2516-4495-49b9-abd3-19124cbeee13"
+                }
+              }
             },
             {
-              "messageKey": "fixUcteRegulations"
+              "messageKey": "fixUcteRegulations",
+              "values": {
+                "id": {
+                  "value": "afedcafe-6fe0-4302-b09f-6f774b394c8b"
+                }
+              }
             }
           ]
         },
@@ -465,6 +538,9 @@
             "severityList": {
               "value": "[]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "0d66f574-88d2-4f3c-acda-97d0ba8c1451"
             }
           },
           "children": [
@@ -477,6 +553,9 @@
                 "severityList": {
                   "value": "[TRACE]",
                   "type": "SEVERITY"
+                },
+                "id": {
+                  "value": "26df6b8d-60a8-4599-8949-527940f39c85"
                 }
               },
               "children": [
@@ -540,6 +619,9 @@
             "severityList": {
               "value": "[TRACE]",
               "type": "SEVERITY"
+            },
+            "id": {
+              "value": "f5a7920f-50dc-4dfd-9d2e-5749775d3da0"
             }
           },
           "children": [
@@ -626,6 +708,7 @@
       ],
       "dictionaries": {
         "default": {
+          "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13": "7165e1a1-6aa5-47a9-ba55-d1ee4e234d13",
           "UcteReading": "Reading UCTE network file",
           "createBus": "Create bus ${bus}",
           "createBuses": "Create buses",

--- a/src/test/resources/reportOne.json
+++ b/src/test/resources/reportOne.json
@@ -2,40 +2,12 @@
   "version": "2.0",
   "reportRoot": {
     "messageKey": "roundTripReporterJsonTest",
-    "values": {
-      "severityList": {
-        "value": "[INFO, TRACE]",
-        "type": "SEVERITY"
-      },
-      "id": {
-        "value": "bf0e389e-aa3e-4256-bc6d-72082d179534",
-        "type": "ID"
-      }
-    },
     "children": [
       {
         "messageKey": "UcteReading",
-        "values": {
-          "severityList": {
-            "value": "[]",
-            "type": "SEVERITY"
-          },
-          "id": {
-            "value": "fbe78039-43c1-4a87-80d8-c5bd25ae98b7"
-          }
-        },
         "children": [
           {
             "messageKey": "fixUcteLines",
-            "values": {
-              "severityList": {
-                "value": "[ERROR]",
-                "type": "SEVERITY"
-              },
-              "id": {
-                "value": "e8b3127e-da04-4431-a26b-a40e1de2f3e4"
-              }
-            },
             "children": [
               {
                 "messageKey": "negativeLineResistance",
@@ -104,55 +76,24 @@
             ]
           },
           {
-            "messageKey": "fixUcteNodes",
-            "values": {
-              "id": {
-                "value": "4a8afba6-1fcc-45fe-81a9-798983f02591"
-              }
-            }
+            "messageKey": "fixUcteNodes"
           },
           {
-            "messageKey": "fixUcteTransformer",
-            "values": {
-              "id": {
-                "value": "6619c7fa-18f6-4a58-9bbc-f12adde95df6"
-              }
-            }
+            "messageKey": "fixUcteTransformer"
           },
           {
-            "messageKey": "fixUcteRegulations",
-            "values": {
-              "id": {
-                "value": "a3af1aea-aa5c-4cb3-8723-e59e8833cd04"
-              }
-            }
+            "messageKey": "fixUcteRegulations"
           }
         ]
       },
       {
         "messageKey": "createBuses",
-        "values": {
-          "severityList": {
-            "value": "[]",
-            "type": "SEVERITY"
-          },
-          "id": {
-            "value": "a46b1761-c908-48b2-98cf-1559fb584a67"
-          }
-        },
         "children": [
           {
             "messageKey": "createBusesSubstation",
             "values": {
               "substation": {
                 "value": "FFFFFF"
-              },
-              "severityList": {
-                "value": "[TRACE]",
-                "type": "SEVERITY"
-              },
-              "id": {
-                "value": "637713e5-d7cf-4cd2-95c3-29667b2fa2de"
               }
             },
             "children": [
@@ -212,15 +153,6 @@
       },
       {
         "messageKey": "createLines",
-        "values": {
-          "severityList": {
-            "value": "[TRACE]",
-            "type": "SEVERITY"
-          },
-          "id": {
-            "value": "23eaa643-e35c-4264-8690-32025d3c164c"
-          }
-        },
         "children": [
           {
             "messageKey": "danglingLineCreation",


### PR DESCRIPTION
Problem is that severityList was set in input files so we were not testing our severity list management and it was not defined in the expected files.

WARNING: we don't use the strict mode on json check (surely because of the presence of changing IDs) then it authorizes additionnal fields and does not check order...

I decided to improve testing to make the migration easier and more reliable.