### PR TITLE
fix rootReportNodeEntity in saveReportNodeRecursively

### DIFF
--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -264,7 +264,7 @@ public class ReportService {
         if (entitiesToSave.size() % MAX_SIZE_INSERT_REPORT_BATCH == 0) {
             self.saveBatchedReports(entitiesToSave);
         }
-        sizedReportNode.getChildren().forEach(child -> saveReportNodeRecursively(rootReportNodeEntity, reportNodeEntity, child, entitiesToSave));
+        sizedReportNode.getChildren().forEach(child -> saveReportNodeRecursively(rootReportNodeEntity, parentReportNodeEntity, child, entitiesToSave));
 
     }
 

--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -263,7 +263,7 @@ public class ReportService {
         if (entitiesToSave.size() % MAX_SIZE_INSERT_REPORT_BATCH == 0) {
             self.saveBatchedReports(entitiesToSave);
         }
-        sizedReportNode.getChildren().forEach(child -> saveReportNodeRecursively(rootReportNodeEntity, parentReportNodeEntity, child, entitiesToSave));
+        sizedReportNode.getChildren().forEach(child -> saveReportNodeRecursively(rootReportNodeEntity, reportNodeEntity, child, entitiesToSave));
 
     }
 

--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -194,16 +194,13 @@ public class ReportService {
     private void appendReportElements(ReportNodeEntity reportEntity, ReportNode reportNode) {
         List<SizedReportNode> sizedReportNodeChildren = new ArrayList<>(reportNode.getChildren().size());
         int newEndOrder = reportEntity.getEndOrder();
-        int startingOrder = newEndOrder + 1;
         int depth = reportEntity.getDepth() + 1;
         for (ReportNode child : reportNode.getChildren()) {
-            SizedReportNode sizedReportNode = SizedReportNode.from(child, startingOrder, depth);
+            SizedReportNode sizedReportNode = SizedReportNode.from(child, newEndOrder + 1, depth);
             sizedReportNodeChildren.add(sizedReportNode);
-            newEndOrder = sizedReportNode.getOrder() + sizedReportNode.getSize() - 1;
-            startingOrder = newEndOrder + 2;
+            newEndOrder += sizedReportNode.getSize();
         }
         // Fix: compute endOrder from the actual last order position of the last child subtree,
-        // instead of adding appendedSize which does not account for the gaps between sibling subtrees.
         reportEntity.setEndOrder(newEndOrder);
         // We don't have to update more ancestors because we only append at root level, and we know it
         // But if we want to generalize appending to any report we should update the severity list of all the ancestors recursively

--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -200,7 +200,7 @@ public class ReportService {
             sizedReportNodeChildren.add(sizedReportNode);
             newEndOrder += sizedReportNode.getSize();
         }
-        // Fix: compute endOrder from the actual last order position of the last child subtree,
+        // compute endOrder from the actual last order position of the last child subtree
         reportEntity.setEndOrder(newEndOrder);
         // We don't have to update more ancestors because we only append at root level, and we know it
         // But if we want to generalize appending to any report we should update the severity list of all the ancestors recursively

--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -205,6 +205,8 @@ public class ReportService {
         // Fix: compute endOrder from the actual last order position of the last child subtree,
         // instead of adding appendedSize which does not account for the gaps between sibling subtrees.
         reportEntity.setEndOrder(newEndOrder);
+        // We don't have to update more ancestors because we only append at root level, and we know it
+        // But if we want to generalize appending to any report we should update the severity list of all the ancestors recursively
         String highestSeverity = sizedReportNodeChildren.stream().map(SizedReportNode::getSeverity).reduce((severity, severity2) -> Severity.fromValue(severity).getLevel() > Severity.fromValue(severity2).getLevel() ? severity : severity2).orElse(Severity.UNKNOWN.toString());
         if (Severity.fromValue(highestSeverity).getLevel() > Severity.fromValue(reportEntity.getSeverity()).getLevel()) {
             reportEntity.setSeverity(highestSeverity);

--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -193,19 +193,18 @@ public class ReportService {
 
     private void appendReportElements(ReportNodeEntity reportEntity, ReportNode reportNode) {
         List<SizedReportNode> sizedReportNodeChildren = new ArrayList<>(reportNode.getChildren().size());
-        int appendedSize = 0;
-        int startingOrder = reportEntity.getEndOrder() + 1;
+        int newEndOrder = reportEntity.getEndOrder();
+        int startingOrder = newEndOrder + 1;
         int depth = reportEntity.getDepth() + 1;
         for (ReportNode child : reportNode.getChildren()) {
             SizedReportNode sizedReportNode = SizedReportNode.from(child, startingOrder, depth);
             sizedReportNodeChildren.add(sizedReportNode);
-            appendedSize += sizedReportNode.getSize();
-            startingOrder = sizedReportNode.getOrder() + sizedReportNode.getSize() + 1;
+            newEndOrder = sizedReportNode.getOrder() + sizedReportNode.getSize() - 1;
+            startingOrder = newEndOrder + 2;
         }
-        reportEntity.setEndOrder(reportEntity.getEndOrder() + appendedSize);
-
-        // We don't have to update more ancestors because we only append at root level, and we know it
-        // But if we want to generalize appending to any report we should update the severity list of all the ancestors recursively
+        // Fix: compute endOrder from the actual last order position of the last child subtree,
+        // instead of adding appendedSize which does not account for the gaps between sibling subtrees.
+        reportEntity.setEndOrder(newEndOrder);
         String highestSeverity = sizedReportNodeChildren.stream().map(SizedReportNode::getSeverity).reduce((severity, severity2) -> Severity.fromValue(severity).getLevel() > Severity.fromValue(severity2).getLevel() ? severity : severity2).orElse(Severity.UNKNOWN.toString());
         if (Severity.fromValue(highestSeverity).getLevel() > Severity.fromValue(reportEntity.getSeverity()).getLevel()) {
             reportEntity.setSeverity(highestSeverity);


### PR DESCRIPTION
## PR Summary
Fix:use the actual last order position of the last child subtree as the new endOrder, instead of adding appendedSize to the current endOrder


