### PR TITLE
Add logic to create child reports with explicit identifiers

### DIFF
--- a/src/main/java/org/gridsuite/report/server/ReportController.java
+++ b/src/main/java/org/gridsuite/report/server/ReportController.java
@@ -153,6 +153,26 @@ public class ReportController {
         service.createOrReplaceReport(id, reportNode);
     }
 
+    @PutMapping(value = "reports/{rootId}/children/{childId}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "Append report as a child with explicit identifier")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Child report has been appended"),
+        @ApiResponse(responseCode = "404", description = "Root report was not found"),
+        @ApiResponse(responseCode = "409", description = "Child report identifier conflicts with an existing report")
+    })
+    public ResponseEntity<Void> createChildReport(@PathVariable("rootId") UUID rootId,
+                                                  @PathVariable("childId") UUID childId,
+                                                  @RequestBody ReportNode reportNode) {
+        try {
+            service.createChildReport(rootId, childId, reportNode);
+            return ResponseEntity.ok().build();
+        } catch (EntityNotFoundException ignored) {
+            return ResponseEntity.notFound().build();
+        } catch (IllegalStateException ignored) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        }
+    }
+
     @PostMapping(value = "reports/{id}/duplicate", consumes = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Duplicate a report")
     @ApiResponses(value = {

--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.annotation.Nullable;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -146,6 +147,32 @@ public class ReportService {
         );
     }
 
+    /**
+     * Creates a new child report under an existing root report.
+     * Validates that the child ID does not already exist and that the target parent is a root report.
+     */
+    @Transactional
+    public void createChildReport(UUID rootId, UUID childId, ReportNode reportNode) {
+        if (reportNodeRepository.existsById(childId)) {
+            throw new IllegalStateException("Report id " + childId + " already exists");
+        }
+
+        ReportNodeEntity rootReportEntity = reportNodeRepository.findById(rootId)
+            .orElseThrow(() -> new EntityNotFoundException("Root report " + rootId + " not found"));
+
+        if (!isRootReport(rootReportEntity)) {
+            throw new IllegalStateException("Report id " + rootId + " is not a root report");
+        }
+
+        appendChildReportElements(rootReportEntity, childId, reportNode);
+    }
+
+    private static boolean isRootReport(ReportNodeEntity reportNodeEntity) {
+        return reportNodeEntity.getId() != null &&
+                reportNodeEntity.getId()
+                    .equals(reportNodeEntity.getRootNode().getId());
+    }
+
     @Transactional
     public void createOrReplaceReport(UUID id, ReportNode reportNode) {
         reportNodeRepository.findById(id).ifPresentOrElse(
@@ -203,19 +230,61 @@ public class ReportService {
             startingOrder = sizedReportNode.getOrder() + sizedReportNode.getSize() + 1;
         }
         reportEntity.setEndOrder(reportEntity.getEndOrder() + appendedSize);
-
-        // We don't have to update more ancestors because we only append at root level, and we know it
-        // But if we want to generalize appending to any report we should update the severity list of all the ancestors recursively
-        String highestSeverity = sizedReportNodeChildren.stream().map(SizedReportNode::getSeverity).reduce((severity, severity2) -> Severity.fromValue(severity).getLevel() > Severity.fromValue(severity2).getLevel() ? severity : severity2).orElse(Severity.UNKNOWN.toString());
-        if (Severity.fromValue(highestSeverity).getLevel() > Severity.fromValue(reportEntity.getSeverity()).getLevel()) {
-            reportEntity.setSeverity(highestSeverity);
-        }
+        updateParentSeverity(reportEntity, sizedReportNodeChildren);
         List<ReportNodeEntity> entitiesToSave = new ArrayList<>(MAX_SIZE_INSERT_REPORT_BATCH);
         entitiesToSave.add(reportEntity);
         sizedReportNodeChildren.forEach(c -> saveReportNodeRecursively(reportEntity, reportEntity, c, entitiesToSave));
 
         if (!entitiesToSave.isEmpty()) {
             self.saveBatchedReports(entitiesToSave);
+        }
+    }
+
+    /**
+     * Appends a report node as a new child entity under the given root, updating order bounds and severity.
+     */
+    private void appendChildReportElements(ReportNodeEntity rootReportEntity, UUID childId, ReportNode reportNode) {
+        int startingOrder = rootReportEntity.getEndOrder() + 1;
+        int depth = rootReportEntity.getDepth() + 1;
+        SizedReportNode sizedChildReportNode = SizedReportNode.from(reportNode, startingOrder, depth);
+
+        rootReportEntity.setEndOrder(rootReportEntity.getEndOrder() + sizedChildReportNode.getSize());
+        rootReportEntity.setLeaf(false);
+        updateParentSeverity(rootReportEntity, List.of(sizedChildReportNode));
+
+        List<ReportNodeEntity> entitiesToSave = new ArrayList<>(MAX_SIZE_INSERT_REPORT_BATCH);
+        entitiesToSave.add(rootReportEntity);
+
+        ReportNodeEntity childReportEntity = ReportNodeEntity.builder()
+            .id(childId)
+            .message(sizedChildReportNode.getMessage())
+            .order(sizedChildReportNode.getOrder())
+            .endOrder(sizedChildReportNode.getOrder() + sizedChildReportNode.getSize() - 1)
+            .isLeaf(sizedChildReportNode.isLeaf())
+            .rootNode(rootReportEntity)
+            .parent(rootReportEntity)
+            .severity(sizedChildReportNode.getSeverity())
+            .depth(sizedChildReportNode.getDepth())
+            .build();
+        entitiesToSave.add(childReportEntity);
+
+        sizedChildReportNode.getChildren().forEach(child ->
+            saveReportNodeRecursively(rootReportEntity, childReportEntity, child, entitiesToSave));
+
+        if (!entitiesToSave.isEmpty()) {
+            self.saveBatchedReports(entitiesToSave);
+        }
+    }
+
+    // We don't have to update more ancestors because we only append at root level.
+    // If appending were generalized to deeper levels we would update severities recursively.
+    private static void updateParentSeverity(ReportNodeEntity reportEntity, List<SizedReportNode> children) {
+        String highestSeverity = children.stream()
+            .map(SizedReportNode::getSeverity)
+            .reduce((severity, severity2) -> Severity.fromValue(severity).getLevel() > Severity.fromValue(severity2).getLevel() ? severity : severity2)
+            .orElse(Severity.UNKNOWN.toString());
+        if (Severity.fromValue(highestSeverity).getLevel() > Severity.fromValue(reportEntity.getSeverity()).getLevel()) {
+            reportEntity.setSeverity(highestSeverity);
         }
     }
 

--- a/src/test/java/org/gridsuite/report/server/ReportControllerTest.java
+++ b/src/test/java/org/gridsuite/report/server/ReportControllerTest.java
@@ -169,6 +169,54 @@ public class ReportControllerTest {
     }
 
     @Test
+    public void testCreateChildReportEndpointAndGetByChildId() throws Exception {
+        insertReport(REPORT_UUID, toString(REPORT_ONE));
+        String childReportUuid = "b2c5e1a1-6aa5-47a9-ba55-d1ee4e234d14";
+        String childReportContent = toString(REPORT_TWO);
+
+        mvc.perform(put(URL_TEMPLATE + "/reports/" + REPORT_UUID + "/children/" + childReportUuid)
+                        .content(childReportContent)
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        MvcResult rootResult = mvc.perform(get(URL_TEMPLATE + "/reports/" + REPORT_UUID))
+                .andExpect(status().isOk())
+                .andReturn();
+        Report rootReport = objectMapper.readValue(rootResult.getResponse().getContentAsString(), Report.class);
+        assertEquals(REPORT_UUID, rootReport.getId().toString());
+        assertTrue(rootReport.getSubReports().stream()
+                .anyMatch(subReport -> childReportUuid.equals(subReport.getId().toString())));
+
+    }
+
+    @Test
+    public void testCreateChildReportEndpointReturnsNotFoundForUnknownRoot() throws Exception {
+        String unknownRootId = "b6f8f518-c4a2-4de0-8e30-5e5618f9856b";
+        String childReportUuid = "b2c5e1a1-6aa5-47a9-ba55-d1ee4e234d14";
+
+        mvc.perform(put(URL_TEMPLATE + "/reports/" + unknownRootId + "/children/" + childReportUuid)
+                        .content(toString(REPORT_ONE))
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void testCreateChildReportEndpointReturnsConflictWhenChildAlreadyExists() throws Exception {
+        insertReport(REPORT_UUID, toString(REPORT_ONE));
+        String childReportUuid = "b2c5e1a1-6aa5-47a9-ba55-d1ee4e234d14";
+
+        mvc.perform(put(URL_TEMPLATE + "/reports/" + REPORT_UUID + "/children/" + childReportUuid)
+                        .content(toString(REPORT_ONE))
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        mvc.perform(put(URL_TEMPLATE + "/reports/" + REPORT_UUID + "/children/" + childReportUuid)
+                        .content(toString(REPORT_ONE))
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
     public void testGetReportWithNoSeverityFilters() throws Exception {
         String testReport1 = toString(REPORT_ONE);
         insertReport(REPORT_UUID, testReport1);

--- a/src/test/java/org/gridsuite/report/server/ReportServiceTest.java
+++ b/src/test/java/org/gridsuite/report/server/ReportServiceTest.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import static org.gridsuite.report.server.SizedReportNode.MAX_MESSAGE_CHAR;
 import static org.gridsuite.report.server.utils.TestUtils.assertRequestsCount;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
@@ -174,6 +175,58 @@ class ReportServiceTest {
         // the two subreports "GENERATOR_MODIFICATION" and "TWO_WINDINGS_TRANSFORMER_MODIFICATION" are added to the same the parent report
         assertEquals(2, parentReportEntity.get().getChildren().size());
         assertEquals(0, reportService.getReportNodeEntity(parentReportEntity.get().getChildren().get(0).getId()).orElseThrow().getChildren().size());
+    }
+
+    @Test
+    void createChildReportUsesProvidedChildIdWithoutCreatingStandaloneDuplicate() {
+        var rootReportNode = ReportNode.newRootReportNode()
+            .withResourceBundles("i18n.reports")
+            .withMessageTemplate("root")
+            .build();
+        UUID rootId = UUID.randomUUID();
+        reportService.createReport(rootId, rootReportNode);
+
+        var stepReportNode = ReportNode.newRootReportNode()
+            .withResourceBundles("i18n.reports")
+            .withMessageTemplate("step")
+            .build();
+        stepReportNode.newReportNode()
+            .withMessageTemplate("step-child")
+            .add();
+        UUID stepReportId = UUID.randomUUID();
+
+        reportService.createChildReport(rootId, stepReportId, stepReportNode);
+
+        assertEquals(3, reportNodeRepository.findAll().size());
+        long parentLessNodes = reportNodeRepository.findAll().stream()
+            .filter(node -> node.getParent() == null)
+            .count();
+        assertEquals(1, parentLessNodes);
+
+        ReportNodeEntity rootReportEntity = reportService.getReportNodeEntity(rootId).orElseThrow();
+        assertEquals(1, rootReportEntity.getChildren().size());
+        assertEquals(stepReportId, rootReportEntity.getChildren().getFirst().getId());
+    }
+
+    @Test
+    void createChildReportFailsIfChildIdAlreadyExists() {
+        var rootReportNode = ReportNode.newRootReportNode()
+            .withResourceBundles("i18n.reports")
+            .withMessageTemplate("root")
+            .build();
+        UUID rootId = UUID.randomUUID();
+        reportService.createReport(rootId, rootReportNode);
+
+        var stepReportNode = ReportNode.newRootReportNode()
+            .withResourceBundles("i18n.reports")
+            .withMessageTemplate("step")
+            .build();
+        UUID stepReportId = UUID.randomUUID();
+        reportService.createChildReport(rootId, stepReportId, stepReportNode);
+
+        assertThrows(
+            IllegalStateException.class,
+            () -> reportService.createChildReport(rootId, stepReportId, stepReportNode));
     }
 
     @Test


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
This pull request adds a new feature to allow creating a report as a child of an existing root report with an explicit identifier


