### PR TITLE
Use UUID v7 to reduce Postgres WAL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.uuid</groupId>
+            <artifactId>java-uuid-generator</artifactId>
+            <version>5.1.0</version>
+        </dependency>
 
         <!-- Runtime dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <dependency>
             <groupId>com.fasterxml.uuid</groupId>
             <artifactId>java-uuid-generator</artifactId>
-            <version>5.1.0</version>
+            <version>5.2.0</version>
         </dependency>
 
         <!-- Runtime dependencies -->

--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -255,7 +255,9 @@ public class ReportService {
         List<ReportNodeEntity> entitiesToSave = new ArrayList<>(MAX_SIZE_INSERT_REPORT_BATCH);
         entitiesToSave.add(rootReportEntity);
 
+        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newV7Generator();
         ReportNodeEntity childReportEntity = ReportNodeEntity.builder()
+            .id(uuidGenerator.generate())
             .message(sizedChildReportNode.getMessage())
             .order(sizedChildReportNode.getOrder())
             .endOrder(sizedChildReportNode.getOrder() + sizedChildReportNode.getSize() - 1)
@@ -266,8 +268,6 @@ public class ReportService {
             .depth(sizedChildReportNode.getDepth())
             .build();
         entitiesToSave.add(childReportEntity);
-
-        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newV7Generator();
         sizedChildReportNode.getChildren().forEach(child ->
             saveReportNodeRecursively(uuidGenerator, rootReportEntity, childReportEntity, child, entitiesToSave));
 

--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -6,6 +6,7 @@
  */
 package org.gridsuite.report.server;
 
+import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
 import com.google.common.collect.Lists;
 import com.powsybl.commons.report.ReportNode;
 import lombok.NonNull;
@@ -17,6 +18,7 @@ import org.gridsuite.report.server.entities.ReportNodeEntity;
 import org.gridsuite.report.server.entities.ReportProjection;
 import org.gridsuite.report.server.entities.ReportTreeItem;
 import org.gridsuite.report.server.repositories.ReportNodeRepository;
+import org.gridsuite.report.server.utils.UuidUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Lazy;
@@ -28,7 +30,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.annotation.Nullable;
-import org.gridsuite.report.server.utils.UuidUtil;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -183,8 +184,9 @@ public class ReportService {
 
         // Add new children
         List<ReportNodeEntity> entitiesToSave = new ArrayList<>(MAX_SIZE_INSERT_REPORT_BATCH);
+        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newUUIDv7Generator();
         sizedReportNode.getChildren().forEach(child ->
-                saveReportNodeRecursively(rootEntity, rootEntity, child, entitiesToSave)
+                saveReportNodeRecursively(uuidGenerator, rootEntity, rootEntity, child, entitiesToSave)
         );
 
         if (!entitiesToSave.isEmpty()) {
@@ -213,7 +215,8 @@ public class ReportService {
         }
         List<ReportNodeEntity> entitiesToSave = new ArrayList<>(MAX_SIZE_INSERT_REPORT_BATCH);
         entitiesToSave.add(reportEntity);
-        sizedReportNodeChildren.forEach(c -> saveReportNodeRecursively(reportEntity, reportEntity, c, entitiesToSave));
+        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newUUIDv7Generator();
+        sizedReportNodeChildren.forEach(c -> saveReportNodeRecursively(uuidGenerator, reportEntity, reportEntity, c, entitiesToSave));
 
         if (!entitiesToSave.isEmpty()) {
             self.saveBatchedReports(entitiesToSave);
@@ -234,9 +237,10 @@ public class ReportService {
             .build();
         persistedReport.setRootNode(persistedReport);
 
+        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newUUIDv7Generator();
         entitiesToSave.add(persistedReport);
         sizedReportNode.getChildren().forEach(c ->
-            saveReportNodeRecursively(persistedReport, persistedReport, c, entitiesToSave)
+            saveReportNodeRecursively(uuidGenerator, persistedReport, persistedReport, c, entitiesToSave)
         );
 
         if (!entitiesToSave.isEmpty()) {
@@ -245,12 +249,14 @@ public class ReportService {
     }
 
     protected void saveReportNodeRecursively(
+        TimeBasedEpochGenerator uuidGenerator,
         ReportNodeEntity rootReportNodeEntity,
         ReportNodeEntity parentReportNodeEntity,
         SizedReportNode sizedReportNode,
         List<ReportNodeEntity> entitiesToSave
     ) {
         var reportNodeEntity = ReportNodeEntity.builder()
+            .id(uuidGenerator.generate())
             .message(sizedReportNode.getMessage())
             .order(sizedReportNode.getOrder())
             .endOrder(sizedReportNode.getOrder() + sizedReportNode.getSize() - 1)
@@ -265,7 +271,7 @@ public class ReportService {
         if (entitiesToSave.size() % MAX_SIZE_INSERT_REPORT_BATCH == 0) {
             self.saveBatchedReports(entitiesToSave);
         }
-        sizedReportNode.getChildren().forEach(child -> saveReportNodeRecursively(rootReportNodeEntity, reportNodeEntity, child, entitiesToSave));
+        sizedReportNode.getChildren().forEach(child -> saveReportNodeRecursively(uuidGenerator, rootReportNodeEntity, reportNodeEntity, child, entitiesToSave));
 
     }
 
@@ -277,6 +283,7 @@ public class ReportService {
 
     @Transactional
     public UUID duplicateReport(UUID rootNodeId) {
+        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newUUIDv7Generator();
         List<ReportProjection> sourceNodes = reportNodeRepository.findAllNodeDataByRootNodeId(rootNodeId);
         if (sourceNodes.isEmpty()) {
             throw new NoSuchElementException("Root node not found");
@@ -285,7 +292,7 @@ public class ReportService {
         // Map old UUIDs to new entities (ordered by depth, so parents are created first)
         Map<UUID, ReportNodeEntity> entityMapping = new HashMap<>();
         List<ReportNodeEntity> batch = new ArrayList<>(MAX_SIZE_INSERT_REPORT_BATCH);
-        UUID newRootId = UuidUtil.generateV7();
+        UUID newRootId = uuidGenerator.generate();
 
         for (ReportProjection source : sourceNodes) {
             boolean isRoot = source.id().equals(rootNodeId);
@@ -293,7 +300,7 @@ public class ReportService {
             ReportNodeEntity parentRef = source.parentId() != null ? entityMapping.get(source.parentId()) : null;
 
             ReportNodeEntity duplicate = ReportNodeEntity.builder()
-                .id(isRoot ? newRootId : UuidUtil.generateV7())
+                .id(isRoot ? newRootId : uuidGenerator.generate())
                 .message(source.message())
                 .order(source.order())
                 .endOrder(source.endOrder())

--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -184,7 +184,7 @@ public class ReportService {
 
         // Add new children
         List<ReportNodeEntity> entitiesToSave = new ArrayList<>(MAX_SIZE_INSERT_REPORT_BATCH);
-        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newUUIDv7Generator();
+        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newV7Generator();
         sizedReportNode.getChildren().forEach(child ->
                 saveReportNodeRecursively(uuidGenerator, rootEntity, rootEntity, child, entitiesToSave)
         );
@@ -213,7 +213,7 @@ public class ReportService {
         }
         List<ReportNodeEntity> entitiesToSave = new ArrayList<>(MAX_SIZE_INSERT_REPORT_BATCH);
         entitiesToSave.add(reportEntity);
-        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newUUIDv7Generator();
+        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newV7Generator();
         sizedReportNodeChildren.forEach(c -> saveReportNodeRecursively(uuidGenerator, reportEntity, reportEntity, c, entitiesToSave));
 
         if (!entitiesToSave.isEmpty()) {
@@ -235,7 +235,7 @@ public class ReportService {
             .build();
         persistedReport.setRootNode(persistedReport);
 
-        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newUUIDv7Generator();
+        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newV7Generator();
         entitiesToSave.add(persistedReport);
         sizedReportNode.getChildren().forEach(c ->
             saveReportNodeRecursively(uuidGenerator, persistedReport, persistedReport, c, entitiesToSave)
@@ -281,7 +281,7 @@ public class ReportService {
 
     @Transactional
     public UUID duplicateReport(UUID rootNodeId) {
-        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newUUIDv7Generator();
+        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newV7Generator();
         List<ReportProjection> sourceNodes = reportNodeRepository.findAllNodeDataByRootNodeId(rootNodeId);
         if (sourceNodes.isEmpty()) {
             throw new NoSuchElementException("Root node not found");

--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -6,7 +6,7 @@
  */
 package org.gridsuite.report.server;
 
-import com.fasterxml.uuid.NoArgGenerator;
+import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
 import com.google.common.collect.Lists;
 import com.powsybl.commons.report.ReportNode;
 import lombok.NonNull;
@@ -211,7 +211,7 @@ public class ReportService {
 
         // Add new children
         List<ReportNodeEntity> entitiesToSave = new ArrayList<>(MAX_SIZE_INSERT_REPORT_BATCH);
-        NoArgGenerator uuidGenerator = UuidUtil.newV7Generator();
+        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newV7Generator();
         sizedReportNode.getChildren().forEach(child ->
                 saveReportNodeRecursively(uuidGenerator, rootEntity, rootEntity, child, entitiesToSave)
         );
@@ -235,7 +235,7 @@ public class ReportService {
         updateParentSeverity(reportEntity, sizedReportNodeChildren);
         List<ReportNodeEntity> entitiesToSave = new ArrayList<>(MAX_SIZE_INSERT_REPORT_BATCH);
         entitiesToSave.add(reportEntity);
-        NoArgGenerator uuidGenerator = UuidUtil.newV7Generator();
+        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newV7Generator();
         sizedReportNodeChildren.forEach(c -> saveReportNodeRecursively(uuidGenerator, reportEntity, reportEntity, c, entitiesToSave));
 
         if (!entitiesToSave.isEmpty()) {
@@ -271,7 +271,7 @@ public class ReportService {
             .build();
         entitiesToSave.add(childReportEntity);
 
-        NoArgGenerator uuidGenerator = UuidUtil.newV7Generator();
+        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newV7Generator();
         sizedChildReportNode.getChildren().forEach(child ->
             saveReportNodeRecursively(uuidGenerator, rootReportEntity, childReportEntity, child, entitiesToSave));
 
@@ -307,7 +307,7 @@ public class ReportService {
         persistedReport.setRootNode(persistedReport);
 
         entitiesToSave.add(persistedReport);
-        NoArgGenerator uuidGenerator = UuidUtil.newV7Generator();
+        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newV7Generator();
         sizedReportNode.getChildren().forEach(c ->
             saveReportNodeRecursively(uuidGenerator, persistedReport, persistedReport, c, entitiesToSave)
         );
@@ -318,7 +318,7 @@ public class ReportService {
     }
 
     protected void saveReportNodeRecursively(
-        NoArgGenerator uuidGenerator,
+        TimeBasedEpochGenerator uuidGenerator,
         ReportNodeEntity rootReportNodeEntity,
         ReportNodeEntity parentReportNodeEntity,
         SizedReportNode sizedReportNode,
@@ -352,7 +352,7 @@ public class ReportService {
 
     @Transactional
     public UUID duplicateReport(UUID rootNodeId) {
-        NoArgGenerator uuidGenerator = UuidUtil.newV7Generator();
+        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newV7Generator();
         List<ReportProjection> sourceNodes = reportNodeRepository.findAllNodeDataByRootNodeId(rootNodeId);
         if (sourceNodes.isEmpty()) {
             throw new NoSuchElementException("Root node not found");

--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.annotation.Nullable;
+import org.gridsuite.report.server.utils.UuidUtil;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -284,7 +285,7 @@ public class ReportService {
         // Map old UUIDs to new entities (ordered by depth, so parents are created first)
         Map<UUID, ReportNodeEntity> entityMapping = new HashMap<>();
         List<ReportNodeEntity> batch = new ArrayList<>(MAX_SIZE_INSERT_REPORT_BATCH);
-        UUID newRootId = UUID.randomUUID();
+        UUID newRootId = UuidUtil.generateV7();
 
         for (ReportProjection source : sourceNodes) {
             boolean isRoot = source.id().equals(rootNodeId);
@@ -292,7 +293,7 @@ public class ReportService {
             ReportNodeEntity parentRef = source.parentId() != null ? entityMapping.get(source.parentId()) : null;
 
             ReportNodeEntity duplicate = ReportNodeEntity.builder()
-                .id(isRoot ? newRootId : UUID.randomUUID())
+                .id(isRoot ? newRootId : UuidUtil.generateV7())
                 .message(source.message())
                 .order(source.order())
                 .endOrder(source.endOrder())

--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -6,7 +6,7 @@
  */
 package org.gridsuite.report.server;
 
-import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
+import com.fasterxml.uuid.NoArgGenerator;
 import com.google.common.collect.Lists;
 import com.powsybl.commons.report.ReportNode;
 import lombok.NonNull;
@@ -184,7 +184,7 @@ public class ReportService {
 
         // Add new children
         List<ReportNodeEntity> entitiesToSave = new ArrayList<>(MAX_SIZE_INSERT_REPORT_BATCH);
-        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newV7Generator();
+        NoArgGenerator uuidGenerator = UuidUtil.newV7Generator();
         sizedReportNode.getChildren().forEach(child ->
                 saveReportNodeRecursively(uuidGenerator, rootEntity, rootEntity, child, entitiesToSave)
         );
@@ -213,7 +213,7 @@ public class ReportService {
         }
         List<ReportNodeEntity> entitiesToSave = new ArrayList<>(MAX_SIZE_INSERT_REPORT_BATCH);
         entitiesToSave.add(reportEntity);
-        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newV7Generator();
+        NoArgGenerator uuidGenerator = UuidUtil.newV7Generator();
         sizedReportNodeChildren.forEach(c -> saveReportNodeRecursively(uuidGenerator, reportEntity, reportEntity, c, entitiesToSave));
 
         if (!entitiesToSave.isEmpty()) {
@@ -235,7 +235,7 @@ public class ReportService {
             .build();
         persistedReport.setRootNode(persistedReport);
 
-        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newV7Generator();
+        NoArgGenerator uuidGenerator = UuidUtil.newV7Generator();
         entitiesToSave.add(persistedReport);
         sizedReportNode.getChildren().forEach(c ->
             saveReportNodeRecursively(uuidGenerator, persistedReport, persistedReport, c, entitiesToSave)
@@ -247,7 +247,7 @@ public class ReportService {
     }
 
     protected void saveReportNodeRecursively(
-        TimeBasedEpochGenerator uuidGenerator,
+        NoArgGenerator uuidGenerator,
         ReportNodeEntity rootReportNodeEntity,
         ReportNodeEntity parentReportNodeEntity,
         SizedReportNode sizedReportNode,
@@ -281,7 +281,7 @@ public class ReportService {
 
     @Transactional
     public UUID duplicateReport(UUID rootNodeId) {
-        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newV7Generator();
+        NoArgGenerator uuidGenerator = UuidUtil.newV7Generator();
         List<ReportProjection> sourceNodes = reportNodeRepository.findAllNodeDataByRootNodeId(rootNodeId);
         if (sourceNodes.isEmpty()) {
             throw new NoSuchElementException("Root node not found");

--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -271,8 +271,9 @@ public class ReportService {
             .build();
         entitiesToSave.add(childReportEntity);
 
+        NoArgGenerator uuidGenerator = UuidUtil.newV7Generator();
         sizedChildReportNode.getChildren().forEach(child ->
-            saveReportNodeRecursively(rootReportEntity, childReportEntity, child, entitiesToSave));
+            saveReportNodeRecursively(uuidGenerator, rootReportEntity, childReportEntity, child, entitiesToSave));
 
         if (!entitiesToSave.isEmpty()) {
             self.saveBatchedReports(entitiesToSave);
@@ -305,8 +306,8 @@ public class ReportService {
             .build();
         persistedReport.setRootNode(persistedReport);
 
-        NoArgGenerator uuidGenerator = UuidUtil.newV7Generator();
         entitiesToSave.add(persistedReport);
+        NoArgGenerator uuidGenerator = UuidUtil.newV7Generator();
         sizedReportNode.getChildren().forEach(c ->
             saveReportNodeRecursively(uuidGenerator, persistedReport, persistedReport, c, entitiesToSave)
         );

--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -352,7 +352,6 @@ public class ReportService {
 
     @Transactional
     public UUID duplicateReport(UUID rootNodeId) {
-        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newV7Generator();
         List<ReportProjection> sourceNodes = reportNodeRepository.findAllNodeDataByRootNodeId(rootNodeId);
         if (sourceNodes.isEmpty()) {
             throw new NoSuchElementException("Root node not found");
@@ -361,7 +360,12 @@ public class ReportService {
         // Map old UUIDs to new entities (ordered by depth, so parents are created first)
         Map<UUID, ReportNodeEntity> entityMapping = new HashMap<>();
         List<ReportNodeEntity> batch = new ArrayList<>(MAX_SIZE_INSERT_REPORT_BATCH);
-        UUID newRootId = uuidGenerator.generate();
+        // UUID v4 is intentionally used for the root node,
+        // to avoid having two different UUID versions for root reports in the database which would be confusing and surprising
+        // root report IDs are managed by study server which generates UUID v4 when creating root reports.
+        // Technical debt: switch to UUID v7 here once the study server generates UUID v7 for root report IDs.
+        UUID newRootId = UUID.randomUUID();
+        TimeBasedEpochGenerator uuidGenerator = UuidUtil.newV7Generator();
 
         for (ReportProjection source : sourceNodes) {
             boolean isRoot = source.id().equals(rootNodeId);

--- a/src/main/java/org/gridsuite/report/server/ReportService.java
+++ b/src/main/java/org/gridsuite/report/server/ReportService.java
@@ -363,7 +363,7 @@ public class ReportService {
         // UUID v4 is intentionally used for the root node,
         // to avoid having two different UUID versions for root reports in the database which would be confusing and surprising
         // root report IDs are managed by study server which generates UUID v4 when creating root reports.
-        // Technical debt: switch to UUID v7 here once the study server generates UUID v7 for root report IDs.
+        // we need to switch to UUID v7 here if the study server generates UUID v7 for root report IDs.
         UUID newRootId = UUID.randomUUID();
         TimeBasedEpochGenerator uuidGenerator = UuidUtil.newV7Generator();
 

--- a/src/main/java/org/gridsuite/report/server/entities/ReportNodeEntity.java
+++ b/src/main/java/org/gridsuite/report/server/entities/ReportNodeEntity.java
@@ -16,6 +16,8 @@ import lombok.Setter;
 import java.util.List;
 import java.util.UUID;
 
+import org.gridsuite.report.server.utils.UuidUtil;
+
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -31,7 +33,7 @@ public class ReportNodeEntity extends AbstractManuallyAssignedIdentifierEntity<U
 
     @Id
     @Builder.Default
-    private UUID id = UUID.randomUUID();
+    private UUID id = UuidUtil.generateV7();
 
     @Column(name = "order_")
     private int order;

--- a/src/main/java/org/gridsuite/report/server/entities/ReportNodeEntity.java
+++ b/src/main/java/org/gridsuite/report/server/entities/ReportNodeEntity.java
@@ -16,8 +16,6 @@ import lombok.Setter;
 import java.util.List;
 import java.util.UUID;
 
-import org.gridsuite.report.server.utils.UuidUtil;
-
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -32,8 +30,7 @@ import org.gridsuite.report.server.utils.UuidUtil;
 public class ReportNodeEntity extends AbstractManuallyAssignedIdentifierEntity<UUID> {
 
     @Id
-    @Builder.Default
-    private UUID id = UuidUtil.generateV7();
+    private UUID id;
 
     @Column(name = "order_")
     private int order;

--- a/src/main/java/org/gridsuite/report/server/utils/UuidUtil.java
+++ b/src/main/java/org/gridsuite/report/server/utils/UuidUtil.java
@@ -15,7 +15,8 @@ public final class UuidUtil {
     }
 
     /**
-    * Create a uuidv7 generator that will generate all uuids for the same root report. The generator is created per root report to avoid having similar uuids for unrelated reports which would be surprising to people looking at the ids.
+    * Create a uuidv7 generator that will generate all uuids for the same root report's children (not for the root report it self which stills in uuidv4).
+    * The generator is created per root report to avoid having similar uuids for unrelated reports which would be surprising to people looking at the ids.
     * NOTE: The uuids would be similar because we generate incremented uuids when generating many uuids during the same millisecond,
     * and we observe that currently we dogenerate up to ~500 report entities in the same millisecond.
     * So for a given root report, we have monotonicity because:
@@ -23,12 +24,21 @@ public final class UuidUtil {
     * - in separate miliseconds, the random value will reset possibly to a smaller value, but the millisecond is greater and the milliseconds comes first.
     * Performance gains:
     *   - With the millisecond prefix, we already remove almost all problems of having many Full Page Images (FPIs) in the PostgreSQL WAL (the FPI come from the index pages, where a new random uuid would have been inserted in the index in a different page virtually every time).
-    *   - With the submillisecond increments, it should additionally improve performance because of sequential writes to the index (not at as impactful as the milliseconds prefix but not hard to implement and may still be worthwile)
+    *   - With the submillisecond part, there are three options:
+    *       1. milliseconds + full random (most random, worst sequential writes)
+    *       2. milliseconds + submillisecond counter + random (what PostgreSQL gen_uuid_v7() does)
+    *       3. milliseconds + random seed then monotonic counter (what timeBasedEpochGenerator does : our choice)
+    *     We picked option 3 both for the sequential write performance gain and because it matches the nature of order_:
+    *     within a root report, order_ is a strictly increasing integer, and so is the submillisecond part of our UUIDs.
+    *     This makes the generated UUID v7 a closer approximation of what the composite id (rootNodeId + order_) would give us natively.
     * NOTE: We currently use PostgreSQL 17, which does not support uuid v7 natively (gen_uuidv7() was only introduced in PostgreSQL 18).
     * This is not a problem because uuid v7 generation happens entirely in Java
     * PostgreSQL only stores the resulting value as a standard UUID column (it does not care about the uuid version, it treats all UUIDs as 128-bit values.)
     * NOTE: with this approach no data migration is needed since uuid v7 is stored as a plain UUID column (fully compatible with existing uuid v4 rows).
-    * we kept the UUID alongside order_ because frontend uses parentId UUIDs to navigate the tree, it is simpler than switching to a composite id (rootNodeId + order_) which would be a breaking API change.
+    * we kept the UUID alongside order_ because it is simpler for now than switching to a composite id (rootNodeId + order_) which would be a breaking API change.
+    * => this is a technical debt: the composite id (rootNodeId + order_) is the right approach
+    * It would permanently solve the WAL bloat at the source: child nodes already have a sequential order_ that uniquely identifies them within a root report,
+    * so (rootNodeId, order_) would be a naturally sequential primary key, UUID v7 here is only a mitigation, not a structural fix.
     */
     public static TimeBasedEpochGenerator newV7Generator() {
         return Generators.timeBasedEpochGenerator();

--- a/src/main/java/org/gridsuite/report/server/utils/UuidUtil.java
+++ b/src/main/java/org/gridsuite/report/server/utils/UuidUtil.java
@@ -30,7 +30,7 @@ public final class UuidUtil {
     * NOTE: with this approach no data migration is needed since uuid v7 is stored as a plain UUID column (fully compatible with existing uuid v4 rows).
     * we kept the UUID alongside order_ because frontend uses parentId UUIDs to navigate the tree, it is simpler than switching to a composite id (rootNodeId + order_) which would be a breaking API change.
     */
-    public static TimeBasedEpochGenerator newUUIDv7Generator() {
+    public static TimeBasedEpochGenerator newV7Generator() {
         return Generators.timeBasedEpochGenerator();
     }
 }

--- a/src/main/java/org/gridsuite/report/server/utils/UuidUtil.java
+++ b/src/main/java/org/gridsuite/report/server/utils/UuidUtil.java
@@ -7,13 +7,13 @@
 package org.gridsuite.report.server.utils;
 
 import com.fasterxml.uuid.Generators;
-import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
+import com.fasterxml.uuid.impl.TimeBasedEpochRandomGenerator;
 
 import java.util.UUID;
 
 public final class UuidUtil {
 
-    private static final TimeBasedEpochGenerator GENERATOR = Generators.timeBasedEpochGenerator();
+    private static final TimeBasedEpochRandomGenerator GENERATOR = Generators.timeBasedEpochRandomGenerator();
 
     private UuidUtil() {
     }

--- a/src/main/java/org/gridsuite/report/server/utils/UuidUtil.java
+++ b/src/main/java/org/gridsuite/report/server/utils/UuidUtil.java
@@ -24,7 +24,7 @@ public final class UuidUtil {
     * Performance gains:
     *   - With the millisecond prefix, we already remove almost all problems of having many Full Page Images (FPIs) in the PostgreSQL WAL (the FPI come from the index pages, where a new random uuid would have been inserted in the index in a different page virtually every time).
     *   - With the submillisecond increments, it should additionally improve performance because of sequential writes to the index (not at as impactful as the milliseconds prefix but not hard to implement and may still be worthwile)
-    * NOTE: PostgreSQL 14 does not support uuid v7 natively (gen_uuidv7() was only introduced in PostgreSQL 17).
+    * NOTE: We currently use PostgreSQL 17, which does not support uuid v7 natively (gen_uuidv7() was only introduced in PostgreSQL 18).
     * This is not a problem because uuid v7 generation happens entirely in Java
     * PostgreSQL only stores the resulting value as a standard UUID column (it does not care about the uuid version, it treats all UUIDs as 128-bit values.)
     * NOTE: with this approach no data migration is needed since uuid v7 is stored as a plain UUID column (fully compatible with existing uuid v4 rows).

--- a/src/main/java/org/gridsuite/report/server/utils/UuidUtil.java
+++ b/src/main/java/org/gridsuite/report/server/utils/UuidUtil.java
@@ -7,7 +7,7 @@
 package org.gridsuite.report.server.utils;
 
 import com.fasterxml.uuid.Generators;
-import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
+import com.fasterxml.uuid.NoArgGenerator;
 
 public final class UuidUtil {
 
@@ -30,7 +30,7 @@ public final class UuidUtil {
     * NOTE: with this approach no data migration is needed since uuid v7 is stored as a plain UUID column (fully compatible with existing uuid v4 rows).
     * we kept the UUID alongside order_ because frontend uses parentId UUIDs to navigate the tree, it is simpler than switching to a composite id (rootNodeId + order_) which would be a breaking API change.
     */
-    public static TimeBasedEpochGenerator newV7Generator() {
+    public static NoArgGenerator newV7Generator() {
         return Generators.timeBasedEpochGenerator();
     }
 }

--- a/src/main/java/org/gridsuite/report/server/utils/UuidUtil.java
+++ b/src/main/java/org/gridsuite/report/server/utils/UuidUtil.java
@@ -7,7 +7,7 @@
 package org.gridsuite.report.server.utils;
 
 import com.fasterxml.uuid.Generators;
-import com.fasterxml.uuid.NoArgGenerator;
+import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
 
 public final class UuidUtil {
 
@@ -30,7 +30,7 @@ public final class UuidUtil {
     * NOTE: with this approach no data migration is needed since uuid v7 is stored as a plain UUID column (fully compatible with existing uuid v4 rows).
     * we kept the UUID alongside order_ because frontend uses parentId UUIDs to navigate the tree, it is simpler than switching to a composite id (rootNodeId + order_) which would be a breaking API change.
     */
-    public static NoArgGenerator newV7Generator() {
+    public static TimeBasedEpochGenerator newV7Generator() {
         return Generators.timeBasedEpochGenerator();
     }
 }

--- a/src/main/java/org/gridsuite/report/server/utils/UuidUtil.java
+++ b/src/main/java/org/gridsuite/report/server/utils/UuidUtil.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.report.server.utils;
+
+import com.fasterxml.uuid.Generators;
+import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
+
+import java.util.UUID;
+
+public final class UuidUtil {
+
+    private static final TimeBasedEpochGenerator GENERATOR = Generators.timeBasedEpochGenerator();
+
+    private UuidUtil() {
+    }
+
+    /**
+     * Generates a UUID v7 (time-ordered). The millisecond timestamp prefix makes
+     * sequential inserts land on the same B-tree leaf page, reducing Full Page
+     * Images (FPIs) in the PostgreSQL WAL.
+     */
+    public static UUID generateV7() {
+        return GENERATOR.generate();
+    }
+}

--- a/src/main/java/org/gridsuite/report/server/utils/UuidUtil.java
+++ b/src/main/java/org/gridsuite/report/server/utils/UuidUtil.java
@@ -7,23 +7,30 @@
 package org.gridsuite.report.server.utils;
 
 import com.fasterxml.uuid.Generators;
-import com.fasterxml.uuid.impl.TimeBasedEpochRandomGenerator;
-
-import java.util.UUID;
+import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
 
 public final class UuidUtil {
-
-    private static final TimeBasedEpochRandomGenerator GENERATOR = Generators.timeBasedEpochRandomGenerator();
 
     private UuidUtil() {
     }
 
     /**
-     * Generates a UUID v7 (time-ordered). The millisecond timestamp prefix makes
-     * sequential inserts land on the same B-tree leaf page, reducing Full Page
-     * Images (FPIs) in the PostgreSQL WAL.
-     */
-    public static UUID generateV7() {
-        return GENERATOR.generate();
+    * Create a uuidv7 generator that will generate all uuids for the same root report. The generator is created per root report to avoid having similar uuids for unrelated reports which would be surprising to people looking at the ids.
+    * NOTE: The uuids would be similar because we generate incremented uuids when generating many uuids during the same millisecond,
+    * and we observe that currently we dogenerate up to ~500 report entities in the same millisecond.
+    * So for a given root report, we have monotonicity because:
+    * - in the same milisecond, the ids will be incremented starting from the random value.
+    * - in separate miliseconds, the random value will reset possibly to a smaller value, but the millisecond is greater and the milliseconds comes first.
+    * Performance gains:
+    *   - With the millisecond prefix, we already remove almost all problems of having many Full Page Images (FPIs) in the PostgreSQL WAL (the FPI come from the index pages, where a new random uuid would have been inserted in the index in a different page virtually every time).
+    *   - With the submillisecond increments, it should additionally improve performance because of sequential writes to the index (not at as impactful as the milliseconds prefix but not hard to implement and may still be worthwile)
+    * NOTE: PostgreSQL 14 does not support uuid v7 natively (gen_uuidv7() was only introduced in PostgreSQL 17).
+    * This is not a problem because uuid v7 generation happens entirely in Java
+    * PostgreSQL only stores the resulting value as a standard UUID column (it does not care about the uuid version, it treats all UUIDs as 128-bit values.)
+    * NOTE: with this approach no data migration is needed since uuid v7 is stored as a plain UUID column (fully compatible with existing uuid v4 rows).
+    * we kept the UUID alongside order_ because frontend uses parentId UUIDs to navigate the tree, it is simpler than switching to a composite id (rootNodeId + order_) which would be a breaking API change.
+    */
+    public static TimeBasedEpochGenerator newUUIDv7Generator() {
+        return Generators.timeBasedEpochGenerator();
     }
 }


### PR DESCRIPTION
Create a uuidv7 generator that will generate all uuids for the same root report's children (not for the root report it self which stills in uuidv4).
The generator is created per root report to avoid having similar uuids for unrelated reports which would be surprising to people looking at the ids.

NOTE: The uuids would be similar because we generate incremented uuids when generating many uuids during the same millisecond, and we observe that currently we dogenerate up to ~500 report entities in the same millisecond.
So for a given root report, we have monotonicity because:
    - in the same milisecond, the ids will be incremented starting from the random value.
    - in separate miliseconds, the random value will reset possibly to a smaller value, but the millisecond is greater and the milliseconds comes first.

Performance gains:
    - With the millisecond prefix, we already remove almost all problems of having many Full Page Images (FPIs) in the PostgreSQL WAL (the FPI come from the index pages, where a new random uuid would have been inserted in the index in a different page virtually every time).
    - With the submillisecond part, there are three options:
            1. milliseconds + full random (most random, worst sequential writes)
            2. milliseconds + submillisecond counter + random (what PostgreSQL gen_uuid_v7() does)
            3. milliseconds + random seed then monotonic counter (what timeBasedEpochGenerator does : our choice)
    We picked option 3 both for the sequential write performance gain and because it matches the nature of order_:
           within a root report, order_ is a strictly increasing integer, and so is the submillisecond part of our UUIDs.
           This makes the generated UUID v7 a closer approximation of what the composite id (rootNodeId + order_) would give us natively.

NOTE: We currently use PostgreSQL 17, which does not support uuid v7 natively (gen_uuidv7() was only introduced in PostgreSQL 18).
This is not a problem because uuid v7 generation happens entirely in Java
PostgreSQL only stores the resulting value as a standard UUID column (it does not care about the uuid version, it treats all UUIDs as 128-bit values.)

NOTE: with this approach no data migration is needed since uuid v7 is stored as a plain UUID column (fully compatible with existing uuid v4 rows).
we kept the UUID alongside order_ because it is simpler for now than switching to a composite id (rootNodeId + order_) which would be a breaking API change.
    
=> this is a technical debt: the composite id (rootNodeId + order_) is the right approach It would permanently solve the WAL bloat at the source: child nodes already have a sequential order_ that uniquely identifies them within a root report,
so (rootNodeId, order_) would be a naturally sequential primary key, UUID v7 here is only a mitigation, not a structural fix.